### PR TITLE
Add HuggingFace embedding model support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,7 @@ from app.models.llamacpp import LlamaCppConfig
 from app.models.huggingface import (
     HuggingFaceCausalConfig,
     HuggingFaceClassificationConfig,
+    HuggingFaceEmbeddingConfig,
 )
 
 
@@ -69,6 +70,8 @@ def parse_instance_config(config_data: Dict[str, Any]) -> Any:
         return HuggingFaceCausalConfig(**config_data)
     elif backend_type == "huggingface_classification":
         return HuggingFaceClassificationConfig(**config_data)
+    elif backend_type == "huggingface_embedding":
+        return HuggingFaceEmbeddingConfig(**config_data)
     else:
         # Fallback to llamacpp
         return LlamaCppConfig(**config_data)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,11 +24,17 @@ from app.models.llamacpp import LlamaCppConfig
 from app.models.huggingface import (
     HuggingFaceCausalConfig,
     HuggingFaceClassificationConfig,
+    HuggingFaceEmbeddingConfig,
 )
 
 # Create the discriminated union type for InstanceConfig
 InstanceConfig = Annotated[
-    Union[LlamaCppConfig, HuggingFaceCausalConfig, HuggingFaceClassificationConfig],
+    Union[
+        LlamaCppConfig,
+        HuggingFaceCausalConfig,
+        HuggingFaceClassificationConfig,
+        HuggingFaceEmbeddingConfig,
+    ],
     Field(discriminator="backend_type"),
 ]
 
@@ -42,6 +48,7 @@ __all__ = [
     "LlamaCppConfig",
     "HuggingFaceCausalConfig",
     "HuggingFaceClassificationConfig",
+    "HuggingFaceEmbeddingConfig",
     # Instance models
     "Instance",
     "InstanceCreate",

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -12,6 +12,7 @@ class BackendType(str, Enum):
     LLAMACPP = "llamacpp"
     HUGGINGFACE_CAUSAL = "huggingface_causal"
     HUGGINGFACE_CLASSIFICATION = "huggingface_classification"
+    HUGGINGFACE_EMBEDDING = "huggingface_embedding"
 
 
 class InstanceStatus(str, Enum):

--- a/app/models/huggingface.py
+++ b/app/models/huggingface.py
@@ -67,3 +67,38 @@ class HuggingFaceClassificationConfig(BaseModel):
         default=None, description="Port (auto-assigned if not specified)"
     )
     api_key: str = Field(..., description="API key for this instance")
+
+
+class HuggingFaceEmbeddingConfig(BaseModel):
+    """Configuration for a HuggingFace embedding model instance using AutoModel."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    backend_type: Literal["huggingface_embedding"] = Field(
+        default="huggingface_embedding", description="Backend type identifier"
+    )
+    model_id: str = Field(
+        ...,
+        description="HuggingFace model ID or local path (e.g., 'sentence-transformers/all-MiniLM-L6-v2')",
+    )
+    alias: str = Field(..., description="Model alias (e.g., embed:minilm)")
+    device: str = Field(
+        default="auto", description="Device to run on: auto, cuda, mps (Mac), cpu"
+    )
+    dtype: str = Field(
+        default="auto", description="Data type: auto, float16, bfloat16, float32"
+    )
+    max_length: int = Field(
+        default=512, description="Maximum sequence length for embeddings"
+    )
+    normalize_embeddings: bool = Field(
+        default=True, description="L2 normalize output embedding vectors"
+    )
+    trust_remote_code: bool = Field(
+        default=False, description="Whether to trust remote code from HuggingFace"
+    )
+    host: str = Field(default="0.0.0.0", description="Host to bind to")
+    port: Optional[int] = Field(
+        default=None, description="Port (auto-assigned if not specified)"
+    )
+    api_key: str = Field(..., description="API key for this instance")

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -35,8 +35,10 @@ def get_runner_for_config(config) -> BackendRunner:
     elif backend_type in (
         BackendType.HUGGINGFACE_CAUSAL,
         BackendType.HUGGINGFACE_CLASSIFICATION,
+        BackendType.HUGGINGFACE_EMBEDDING,
         "huggingface_causal",
         "huggingface_classification",
+        "huggingface_embedding",
     ):
         return HuggingFaceRunner()
     else:
@@ -85,17 +87,17 @@ class ProcessManager:
 
     def _get_available_port(self) -> int:
         """Get the lowest available port starting from settings.start_port.
-        
+
         Finds the first port (starting from start_port) that is:
         1. Not assigned to a currently running instance
         2. Not currently bound by any process
         """
         assigned_ports = self._get_assigned_ports()
         port = settings.start_port
-        
+
         while port in assigned_ports or not self._is_port_available(port):
             port += 1
-        
+
         return port
 
     def _read_logs(
@@ -391,7 +393,7 @@ class ProcessManager:
         # Parse config if it's a dict (from FastAPI request body)
         if isinstance(config, dict):
             config = parse_instance_config(config)
-        
+
         instance_id = str(uuid.uuid4())
 
         # Determine supported endpoints based on backend type

--- a/app/routes/instances.py
+++ b/app/routes/instances.py
@@ -61,7 +61,7 @@ async def update_instance(instance_id: str, data: InstanceUpdate):
         config = data.config
         if isinstance(config, dict):
             config = parse_instance_config(config)
-        
+
         instance.config = config
         config_manager.update_instance(instance_id, instance)
         return InstanceResponse(


### PR DESCRIPTION
This pull request adds support for HuggingFace embedding models to the backend and server infrastructure. It introduces a new backend type (`huggingface_embedding`), configuration model, and endpoint for generating text embeddings, alongside updates to the process manager and server logic to handle embedding requests. The changes ensure that embedding models can be loaded, configured, and queried using an OpenAI-compatible `/v1/embeddings` endpoint.

**Embedding model support:**

* Added `HuggingFaceEmbeddingConfig` to `app/models/huggingface.py` and updated the union type `InstanceConfig` to include embedding models, allowing configuration and instantiation of HuggingFace embedding instances.
* Introduced the new backend type `huggingface_embedding` in `BackendType` (app/models/base.py) and updated config parsing and process manager logic to recognize and handle embedding backends.

**Server and runner enhancements:**

* Updated `HuggingFaceRunner` and related command-building logic to support embedding models, including passing the `normalize_embeddings` flag, and added `/v1/embeddings` to the list of supported endpoints for embedding backends.
* Extended `hf_server.py` to load and manage embedding models, including new argument parsing for embedding-specific options and normalization, and storing normalization settings in server state.
* 
**API and endpoint additions:**

* Implemented the `/v1/embeddings` endpoint in `hf_server.py`, supporting batch and single text input, mean pooling, optional L2 normalization, and dimension truncation, returning embedding vectors in OpenAI-compatible format.

**Minor refactors and formatting:**

* Minor formatting and import updates throughout `hf_server.py` for clarity and consistency.