### PR TITLE
Add configurable `roles` field to solar-host

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,7 @@ class ConfigManager:
     def __init__(self, config_file: Optional[str] = None):
         self.config_file = Path(config_file or settings.config_file)
         self.instances: Dict[str, Instance] = {}
+        self.roles: List[str] = ["inference"]
         self.load()
 
     def load(self):
@@ -105,6 +106,7 @@ class ConfigManager:
             try:
                 with open(self.config_file, "r") as f:
                     data = json.load(f)
+                    self.roles = data.get("roles", ["inference"])
                     for instance_data in data.get("instances", []):
                         try:
                             # Migrate config if needed
@@ -137,10 +139,11 @@ class ConfigManager:
         """Save configuration to disk."""
         try:
             data = {
+                "roles": self.roles,
                 "instances": [
                     instance.model_dump(mode="json")
                     for instance in self.instances.values()
-                ]
+                ],
             }
             self.config_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self.config_file, "w") as f:

--- a/app/ws_client.py
+++ b/app/ws_client.py
@@ -242,6 +242,7 @@ class SolarControlClient:
             {
                 "host_name": self.host_name,
                 "instances": instances,
+                "roles": config_manager.roles,
             },
             namespace=self.NAMESPACE,
         )


### PR DESCRIPTION
## Description
Solar Host has no concept of host roles — all hosts are treated uniformly by Solar Control. SuperNova needs hosts to declare capabilities (inference, training, or both) so the orchestrator can route jobs to the right hosts. This PR adds a `roles` field to `config.json` and includes it in the Socket.IO registration payload.

## Changes
- Added `roles` attribute (`List[str]`, default `["inference"]`) to `ConfigManager` in `app/config.py`
- `ConfigManager.load()` reads `roles` from `config.json`, falling back to `["inference"]` for existing configs
- `ConfigManager.save()` persists `roles` alongside `instances`
- `_send_registration()` in `app/ws_client.py` includes `roles` in the registration event payload sent to solar-control

## Related Issues
Resolves #5 