### PR TITLE
S-002: Add GPU type detection to host registration

### DIFF
--- a/app/memory_monitor.py
+++ b/app/memory_monitor.py
@@ -1,5 +1,6 @@
 """
-Memory monitoring for GPU VRAM (NVIDIA) and system RAM (macOS).
+Memory monitoring for GPU VRAM (NVIDIA) and system RAM (macOS),
+and GPU type detection.
 """
 
 import platform
@@ -11,6 +12,9 @@ import psutil
 _memory_cache: Optional[Dict] = None
 _cache_timestamp: float = 0
 CACHE_DURATION = 5.0  # seconds
+
+# GPU type is constant for the lifetime of the process
+_gpu_type_cache: Optional[str] = None
 
 
 def get_memory_info() -> Optional[Dict[str, Union[float, str]]]:
@@ -45,6 +49,36 @@ def get_memory_info() -> Optional[Dict[str, Union[float, str]]]:
         _cache_timestamp = current_time
 
     return result
+
+
+def detect_gpu_type() -> str:
+    """Detect the acceleration backend available on this host.
+
+    Returns one of: "nvidia_cuda", "apple_mps", "cpu".
+    Result is cached for the lifetime of the process.
+    """
+    global _gpu_type_cache
+    if _gpu_type_cache is not None:
+        return _gpu_type_cache
+
+    try:
+        import pynvml  # type: ignore
+
+        pynvml.nvmlInit()
+        if pynvml.nvmlDeviceGetCount() > 0:
+            pynvml.nvmlShutdown()
+            _gpu_type_cache = "nvidia_cuda"
+            return _gpu_type_cache
+        pynvml.nvmlShutdown()
+    except Exception:
+        pass
+
+    if platform.system() == "Darwin":
+        _gpu_type_cache = "apple_mps"
+        return _gpu_type_cache
+
+    _gpu_type_cache = "cpu"
+    return _gpu_type_cache
 
 
 def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:

--- a/app/ws_client.py
+++ b/app/ws_client.py
@@ -237,12 +237,15 @@ class SolarControlClient:
                 }
             )
 
+        from app.memory_monitor import detect_gpu_type
+
         await self._sio.emit(
             "registration",
             {
                 "host_name": self.host_name,
                 "instances": instances,
                 "roles": config_manager.roles,
+                "gpu_type": detect_gpu_type(),
             },
             namespace=self.NAMESPACE,
         )
@@ -306,7 +309,7 @@ class SolarControlClient:
 
     async def send_health(self, memory: Optional[Dict[str, Any]] = None):
         """Send host health/memory update to solar-control."""
-        from app.memory_monitor import get_memory_info
+        from app.memory_monitor import get_memory_info, detect_gpu_type
         from app.config import config_manager
 
         if memory is None:
@@ -321,6 +324,7 @@ class SolarControlClient:
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "data": {
                     "memory": memory,
+                    "gpu_type": detect_gpu_type(),
                     "instance_count": len(instances),
                     "running_instance_count": running_count,
                 },


### PR DESCRIPTION
## Description

Add GPU acceleration backend detection so solar-control and SuperNova know
whether a host has NVIDIA CUDA, Apple MPS, or CPU-only compute available.
This is needed for SuperNova to select compatible training images and allocate
resources correctly.

## Changes

- Add `detect_gpu_type()` to `app/memory_monitor.py` — probes pynvml for
  NVIDIA GPUs, checks `platform.system()` for macOS/MPS, falls back to
  `"cpu"`. Result is cached for the process lifetime.
- Include `gpu_type` in the `registration` event payload (`_send_registration()`).
- Include `gpu_type` in the `host_health` event payload (`send_health()`).

## Related Issues

Resolves #6