### PR TITLE
S-004: Add available_gb to /memory and host health

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -208,17 +208,22 @@ async def get_memory():
     try:
         used_gb = float(memory_info.get("used_gb"))  # type: ignore[arg-type]
         total_gb = float(memory_info.get("total_gb"))  # type: ignore[arg-type]
+        available_gb = float(memory_info.get("available_gb"))  # type: ignore[arg-type]
         percent = float(memory_info.get("percent"))  # type: ignore[arg-type]
         memory_type = str(memory_info.get("memory_type"))
     except Exception:
-        # Fallback values if coercion fails
         used_gb = 0.0
         total_gb = 0.0
+        available_gb = 0.0
         percent = 0.0
         memory_type = "RAM"
 
     return MemoryInfo(
-        used_gb=used_gb, total_gb=total_gb, percent=percent, memory_type=memory_type
+        used_gb=used_gb,
+        total_gb=total_gb,
+        available_gb=available_gb,
+        percent=percent,
+        memory_type=memory_type,
     )
 
 

--- a/app/memory_monitor.py
+++ b/app/memory_monitor.py
@@ -24,6 +24,7 @@ def get_memory_info() -> Optional[Dict[str, Union[float, str]]]:
     Returns dict with:
     - used_gb: Used memory in GB
     - total_gb: Total memory in GB
+    - available_gb: Memory available for new workloads (total - used)
     - percent: Usage percentage
     - memory_type: "VRAM" or "RAM"
 
@@ -108,9 +109,12 @@ def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:
         total_gb = total_capacity / (1024**3)
         percent = (total_used / total_capacity * 100) if total_capacity > 0 else 0
 
+        available_gb = total_gb - used_gb
+
         return {
             "used_gb": round(used_gb, 2),
             "total_gb": round(total_gb, 2),
+            "available_gb": round(available_gb, 2),
             "percent": round(percent, 2),
             "memory_type": "VRAM",
         }
@@ -129,9 +133,12 @@ def _get_mac_memory() -> Optional[Dict[str, Union[float, str]]]:
         total_gb = mem.total / (1024**3)
         percent = mem.percent
 
+        available_gb = total_gb - used_gb
+
         return {
             "used_gb": round(used_gb, 2),
             "total_gb": round(total_gb, 2),
+            "available_gb": round(available_gb, 2),
             "percent": round(percent, 2),
             "memory_type": "RAM",
         }

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -75,6 +75,9 @@ class MemoryInfo(BaseModel):
 
     used_gb: float = Field(..., description="Used memory in GB")
     total_gb: float = Field(..., description="Total memory in GB")
+    available_gb: float = Field(
+        ..., description="Memory available for new workloads (total - used)"
+    )
     percent: float = Field(..., description="Usage percentage")
     memory_type: str = Field(..., description="Type of memory (VRAM or RAM)")
 


### PR DESCRIPTION
## Description

Extends Solar Host’s `/memory` response and the `host_health` Socket.IO payload with **`available_gb`**, computed as **total − used** from the same sources as today (pynvml VRAM / psutil RAM). That matches “memory left for new workloads” given system-wide usage already includes running processes. Solar Control’s `MemoryInfo` model accepts the new field; **`available_gb` is optional** so existing JSONB `hosts.memory` rows without it still load.

## Changes
- `app/memory_monitor.py` — document and return `available_gb` in NVIDIA and macOS paths.
- `app/models/base.py` — add `available_gb` to `MemoryInfo`.
- `app/main.py` — `/memory` returns `available_gb` (no `ws_client` change; health already forwards the memory dict).

## Related Issues

Closes #8 