### PR TITLE
feat(solar-host): implement GET /models endpoint (S-014)

### DIFF
--- a/solar_host/main.py
+++ b/solar_host/main.py
@@ -8,7 +8,7 @@ from solar_host import __version__
 from solar_host.config import settings
 from solar_host.models_manager import ensure_models_dir, get_models_dir
 from solar_host.process_manager import process_manager
-from solar_host.routes import instances, websockets
+from solar_host.routes import instances, models, websockets
 from solar_host.ws_client import init_clients, get_clients, get_client, broadcast_health
 
 
@@ -125,6 +125,7 @@ async def verify_api_key(request: Request, call_next):
 
 # Include routers
 app.include_router(instances.router)
+app.include_router(models.router)
 app.include_router(websockets.router)
 
 

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -1,0 +1,123 @@
+"""GET /models endpoint — lists models from the managed models directory.
+
+Source data is the manifest (single source of truth for tracked models).
+Subdirectories in MODELS_DIR that are not in the manifest are also included
+as untracked entries so that manually-placed models are visible.
+Orphaned manifest entries (directory deleted) are included as well so that
+consumers such as the HuggingFace resolver (S-012) can distinguish "known but
+missing" from "never seen".
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from solar_host.models_manager import get_models_dir, read_manifest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+
+class ModelEntry(BaseModel):
+    """A single model entry returned by GET /models."""
+
+    name: str
+    path: str
+    size_bytes: int
+    source_uri: Optional[str] = None
+    checksum: Optional[str] = None
+    downloaded_at: Optional[str] = None
+    in_manifest: bool
+
+
+def _dir_size(directory: Path) -> int:
+    """Return the total size in bytes of all files under *directory*."""
+    return sum(f.stat().st_size for f in directory.rglob("*") if f.is_file())
+
+
+def _build_model_list(models_dir: Path) -> List[ModelEntry]:
+    """Build the list of ModelEntry objects synchronously (for thread offload)."""
+    manifest = read_manifest()
+
+    # Index manifest entries by slug for O(1) lookup.
+    by_slug: dict[str, object] = {entry.slug: entry for entry in manifest.models}
+
+    results: List[ModelEntry] = []
+    seen_slugs: set[str] = set()
+
+    # Walk subdirectories in MODELS_DIR.
+    if models_dir.is_dir():
+        for child in sorted(models_dir.iterdir()):
+            if not child.is_dir():
+                continue
+
+            slug = child.name
+            seen_slugs.add(slug)
+
+            if slug in by_slug:
+                entry = by_slug[slug]  # type: ignore[assignment]
+                results.append(
+                    ModelEntry(
+                        name=entry.slug,  # type: ignore[attr-defined]
+                        path=entry.path,  # type: ignore[attr-defined]
+                        size_bytes=entry.size_bytes,  # type: ignore[attr-defined]
+                        source_uri=entry.source_uri,  # type: ignore[attr-defined]
+                        checksum=entry.digest,  # type: ignore[attr-defined]
+                        downloaded_at=entry.downloaded_at,  # type: ignore[attr-defined]
+                        in_manifest=True,
+                    )
+                )
+            else:
+                # Untracked model — compute size from disk.
+                try:
+                    size = _dir_size(child)
+                except OSError:
+                    size = 0
+                results.append(
+                    ModelEntry(
+                        name=slug,
+                        path=str(child.resolve()),
+                        size_bytes=size,
+                        source_uri=None,
+                        checksum=None,
+                        downloaded_at=None,
+                        in_manifest=False,
+                    )
+                )
+
+    # Include orphaned manifest entries (in manifest but directory absent).
+    for entry in manifest.models:
+        if entry.slug not in seen_slugs:
+            results.append(
+                ModelEntry(
+                    name=entry.slug,
+                    path=entry.path,
+                    size_bytes=entry.size_bytes,
+                    source_uri=entry.source_uri,
+                    checksum=entry.digest,
+                    downloaded_at=entry.downloaded_at,
+                    in_manifest=True,
+                )
+            )
+
+    return results
+
+
+@router.get("", response_model=List[ModelEntry], summary="List managed models")
+async def list_models() -> List[ModelEntry]:
+    """Return all models known to this host.
+
+    Combines manifest-tracked models with any subdirectories in MODELS_DIR
+    that are not yet in the manifest (e.g. manually placed files).
+    Manifest entries whose directories have been deleted are also returned so
+    that callers can detect orphaned cache entries.
+
+    Returns an empty list if the models directory or manifest does not exist.
+    """
+    models_dir = get_models_dir()
+    return await asyncio.to_thread(_build_model_list, models_dir)

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -1,24 +1,17 @@
-"""GET /models endpoint — lists models from the managed models directory.
+"""GET /models — lists models recorded in MODELS_DIR/manifest.json.
 
-Source data is the manifest (single source of truth for tracked models).
-Subdirectories in MODELS_DIR that are not in the manifest are also included
-as untracked entries so that manually-placed models are visible.
-Orphaned manifest entries (directory deleted) are included as well so that
-consumers such as the HuggingFace resolver (S-012) can distinguish "known but
-missing" from "never seen".
+Per S-009, the manifest is the single source of truth. This endpoint does not
+scan the filesystem for models; only entries present in the manifest are
+returned. Missing or invalid manifest yields an empty list (see read_manifest).
 """
 
 import asyncio
-import logging
-from pathlib import Path
 from typing import List, Optional
 
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from solar_host.models_manager import get_models_dir, read_manifest
-
-logger = logging.getLogger(__name__)
+from solar_host.models_manager import read_manifest
 
 router = APIRouter(prefix="/models", tags=["models"])
 
@@ -32,92 +25,30 @@ class ModelEntry(BaseModel):
     source_uri: Optional[str] = None
     checksum: Optional[str] = None
     downloaded_at: Optional[str] = None
-    in_manifest: bool
 
 
-def _dir_size(directory: Path) -> int:
-    """Return the total size in bytes of all files under *directory*."""
-    return sum(f.stat().st_size for f in directory.rglob("*") if f.is_file())
-
-
-def _build_model_list(models_dir: Path) -> List[ModelEntry]:
-    """Build the list of ModelEntry objects synchronously (for thread offload)."""
+def _manifest_to_entries() -> List[ModelEntry]:
     manifest = read_manifest()
-
-    # Index manifest entries by slug for O(1) lookup.
-    by_slug: dict[str, object] = {entry.slug: entry for entry in manifest.models}
-
-    results: List[ModelEntry] = []
-    seen_slugs: set[str] = set()
-
-    # Walk subdirectories in MODELS_DIR.
-    if models_dir.is_dir():
-        for child in sorted(models_dir.iterdir()):
-            if not child.is_dir():
-                continue
-
-            slug = child.name
-            seen_slugs.add(slug)
-
-            if slug in by_slug:
-                entry = by_slug[slug]  # type: ignore[assignment]
-                results.append(
-                    ModelEntry(
-                        name=entry.slug,  # type: ignore[attr-defined]
-                        path=entry.path,  # type: ignore[attr-defined]
-                        size_bytes=entry.size_bytes,  # type: ignore[attr-defined]
-                        source_uri=entry.source_uri,  # type: ignore[attr-defined]
-                        checksum=entry.digest,  # type: ignore[attr-defined]
-                        downloaded_at=entry.downloaded_at,  # type: ignore[attr-defined]
-                        in_manifest=True,
-                    )
-                )
-            else:
-                # Untracked model — compute size from disk.
-                try:
-                    size = _dir_size(child)
-                except OSError:
-                    size = 0
-                results.append(
-                    ModelEntry(
-                        name=slug,
-                        path=str(child.resolve()),
-                        size_bytes=size,
-                        source_uri=None,
-                        checksum=None,
-                        downloaded_at=None,
-                        in_manifest=False,
-                    )
-                )
-
-    # Include orphaned manifest entries (in manifest but directory absent).
-    for entry in manifest.models:
-        if entry.slug not in seen_slugs:
-            results.append(
-                ModelEntry(
-                    name=entry.slug,
-                    path=entry.path,
-                    size_bytes=entry.size_bytes,
-                    source_uri=entry.source_uri,
-                    checksum=entry.digest,
-                    downloaded_at=entry.downloaded_at,
-                    in_manifest=True,
-                )
-            )
-
-    return results
+    return [
+        ModelEntry(
+            name=e.slug,
+            path=e.path,
+            size_bytes=e.size_bytes,
+            source_uri=e.source_uri,
+            checksum=e.digest,
+            downloaded_at=e.downloaded_at,
+        )
+        for e in manifest.models
+    ]
 
 
 @router.get("", response_model=List[ModelEntry], summary="List managed models")
 async def list_models() -> List[ModelEntry]:
-    """Return all models known to this host.
+    """Return all models listed in the managed models manifest.
 
-    Combines manifest-tracked models with any subdirectories in MODELS_DIR
-    that are not yet in the manifest (e.g. manually placed files).
-    Manifest entries whose directories have been deleted are also returned so
-    that callers can detect orphaned cache entries.
+    Data comes only from ``manifest.json`` under ``MODELS_DIR`` (see
+    ``read_manifest``). No directory scanning is performed.
 
-    Returns an empty list if the models directory or manifest does not exist.
+    Returns an empty list when the manifest is missing, empty, or unreadable.
     """
-    models_dir = get_models_dir()
-    return await asyncio.to_thread(_build_model_list, models_dir)
+    return await asyncio.to_thread(_manifest_to_entries)

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -7,11 +7,11 @@ from starlette.testclient import TestClient
 
 from solar_host.main import app
 from solar_host.models_manager import (
+    Manifest,
     ManifestEntry,
     add_manifest_entry,
     ensure_models_dir,
     write_manifest,
-    Manifest,
 )
 
 API_KEY = "test-key-s014"
@@ -28,8 +28,6 @@ def _isolated_env(tmp_path: Path, monkeypatch):
     API key. The solar_control_url is cleared so no WebSocket clients are
     started during the lifespan."""
     models = tmp_path / "models"
-    # settings is a module-level singleton; patching the object attribute
-    # propagates to all modules that imported it.
     monkeypatch.setattr("solar_host.config.settings.models_dir", str(models))
     monkeypatch.setattr("solar_host.config.settings.solar_control_url", "")
     monkeypatch.setattr("solar_host.config.settings.api_key", API_KEY)
@@ -86,7 +84,6 @@ class TestAuth:
 
 class TestEmptyState:
     def test_no_manifest_returns_empty_list(self, client: TestClient):
-        """No models directory and no manifest → empty list, no error."""
         resp = client.get("/models", headers=_headers())
         assert resp.status_code == 200
         assert resp.json() == []
@@ -100,7 +97,7 @@ class TestEmptyState:
 
 
 # ---------------------------------------------------------------------------
-# Manifest-backed models
+# Manifest-only listing
 # ---------------------------------------------------------------------------
 
 
@@ -118,7 +115,7 @@ class TestManifestModels:
         assert entry["size_bytes"] == 4815162342
         assert entry["checksum"] == "sha256:abc123"
         assert entry["downloaded_at"] == "2026-03-31T14:22:00Z"
-        assert entry["in_manifest"] is True
+        assert "in_manifest" not in entry
 
     def test_multiple_manifest_entries(self, client: TestClient):
         ensure_models_dir()
@@ -150,136 +147,51 @@ class TestManifestModels:
         assert data[0]["checksum"] is None
 
     def test_path_comes_from_manifest(self, client: TestClient):
-        """The path in the response is taken from the manifest entry, not
-        derived from the current models dir."""
         ensure_models_dir()
         add_manifest_entry(_make_entry(path="/custom/absolute/path/to/model"))
         resp = client.get("/models", headers=_headers())
         assert resp.json()[0]["path"] == "/custom/absolute/path/to/model"
 
 
-# ---------------------------------------------------------------------------
-# Orphaned manifest entries (in manifest but directory missing)
-# ---------------------------------------------------------------------------
-
-
-class TestOrphanedManifestEntries:
-    def test_orphaned_entry_still_returned(self, client: TestClient):
-        """Manifest entry whose directory does not exist is returned with
-        in_manifest=True so callers can detect stale cache entries."""
+class TestManifestOnlyNoDirectoryScan:
+    def test_manifest_entry_returned_without_directory_on_disk(
+        self, client: TestClient
+    ):
+        """Manifest rows are returned even when the model directory does not exist."""
         ensure_models_dir()
         add_manifest_entry(_make_entry())
-        # Do NOT create the directory — simulate orphaned entry.
         resp = client.get("/models", headers=_headers())
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["in_manifest"] is True
         assert data[0]["name"] == "repo--iris-osl--v3"
 
-
-# ---------------------------------------------------------------------------
-# Untracked directories (on disk but not in manifest)
-# ---------------------------------------------------------------------------
-
-
-class TestUntrackedDirectories:
-    def test_untracked_dir_is_included(self, client: TestClient, _isolated_env: Path):
-        ensure_models_dir()
-        # Manually create a model directory with a file.
-        model_dir = _isolated_env / "manually-placed-model"
-        model_dir.mkdir()
-        (model_dir / "model.gguf").write_bytes(b"x" * 512)
-
-        resp = client.get("/models", headers=_headers())
-        assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) == 1
-        entry = data[0]
-        assert entry["name"] == "manually-placed-model"
-        assert entry["in_manifest"] is False
-        assert entry["source_uri"] is None
-        assert entry["checksum"] is None
-        assert entry["size_bytes"] == 512
-
-    def test_untracked_dir_path_is_absolute(
+    def test_extra_directories_on_disk_ignored(
         self, client: TestClient, _isolated_env: Path
     ):
+        """Directories under MODELS_DIR that are not in the manifest are not listed."""
         ensure_models_dir()
-        model_dir = _isolated_env / "some-model"
-        model_dir.mkdir()
-
-        resp = client.get("/models", headers=_headers())
-        data = resp.json()
-        assert Path(data[0]["path"]).is_absolute()
-
-    def test_files_in_models_dir_root_are_ignored(
-        self, client: TestClient, _isolated_env: Path
-    ):
-        """Non-directory entries in MODELS_DIR (e.g. manifest.json) must not
-        appear in the response."""
-        ensure_models_dir()
-        # manifest.json is written by write_manifest; also add a stray file.
         write_manifest(Manifest(models=[]))
-        (_isolated_env / "stray-file.txt").write_text("hello")
+        orphan = _isolated_env / "manually-placed-model"
+        orphan.mkdir()
+        (orphan / "model.gguf").write_bytes(b"x" * 512)
 
         resp = client.get("/models", headers=_headers())
         assert resp.json() == []
 
-
-# ---------------------------------------------------------------------------
-# Mixed: manifest + untracked
-# ---------------------------------------------------------------------------
-
-
-class TestMixed:
-    def test_manifest_and_untracked_both_returned(
+    def test_only_manifest_entries_when_both_exist(
         self, client: TestClient, _isolated_env: Path
     ):
         ensure_models_dir()
-        # Tracked model (manifest entry, directory present).
         tracked_dir = _isolated_env / "repo--iris-osl--v3"
         tracked_dir.mkdir()
-        add_manifest_entry(
-            _make_entry(
-                path=str(tracked_dir.resolve()),
-                size_bytes=100,
-            )
-        )
-        # Untracked model (directory only, no manifest entry).
+        add_manifest_entry(_make_entry(path=str(tracked_dir.resolve()), size_bytes=100))
         untracked_dir = _isolated_env / "manually-placed"
         untracked_dir.mkdir()
         (untracked_dir / "weights.bin").write_bytes(b"\x00" * 256)
 
         resp = client.get("/models", headers=_headers())
-        assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) == 2
-
-        by_name = {e["name"]: e for e in data}
-        assert "repo--iris-osl--v3" in by_name
-        assert "manually-placed" in by_name
-
-        tracked = by_name["repo--iris-osl--v3"]
-        assert tracked["in_manifest"] is True
-        assert tracked["size_bytes"] == 100  # from manifest
-
-        untracked = by_name["manually-placed"]
-        assert untracked["in_manifest"] is False
-        assert untracked["size_bytes"] == 256  # computed from disk
-
-    def test_manifest_entry_takes_priority_over_disk_for_size(
-        self, client: TestClient, _isolated_env: Path
-    ):
-        """When a directory exists AND has a manifest entry, the size from
-        the manifest is used (not recomputed from disk)."""
-        ensure_models_dir()
-        model_dir = _isolated_env / "repo--iris-osl--v3"
-        model_dir.mkdir()
-        (model_dir / "model.bin").write_bytes(b"\x00" * 64)
-        add_manifest_entry(_make_entry(path=str(model_dir.resolve()), size_bytes=9999))
-
-        resp = client.get("/models", headers=_headers())
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["size_bytes"] == 9999  # manifest wins
+        assert data[0]["name"] == "repo--iris-osl--v3"
+        assert data[0]["size_bytes"] == 100

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -1,0 +1,285 @@
+"""Tests for GET /models endpoint (solar_host/routes/models.py)."""
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from solar_host.main import app
+from solar_host.models_manager import (
+    ManifestEntry,
+    add_manifest_entry,
+    ensure_models_dir,
+    write_manifest,
+    Manifest,
+)
+
+API_KEY = "test-key-s014"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path: Path, monkeypatch):
+    """Patch settings so each test gets a fresh tmp models dir and a fixed
+    API key. The solar_control_url is cleared so no WebSocket clients are
+    started during the lifespan."""
+    models = tmp_path / "models"
+    # settings is a module-level singleton; patching the object attribute
+    # propagates to all modules that imported it.
+    monkeypatch.setattr("solar_host.config.settings.models_dir", str(models))
+    monkeypatch.setattr("solar_host.config.settings.solar_control_url", "")
+    monkeypatch.setattr("solar_host.config.settings.api_key", API_KEY)
+    return models
+
+
+@pytest.fixture()
+def client():
+    """HTTP test client that runs the full app lifespan."""
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def _headers() -> dict:
+    return {"X-API-Key": API_KEY}
+
+
+def _make_entry(**overrides) -> ManifestEntry:
+    defaults = {
+        "slug": "repo--iris-osl--v3",
+        "source_uri": "repo://iris-osl:v3",
+        "path": "/opt/solar/models/repo--iris-osl--v3",
+        "size_bytes": 4815162342,
+        "digest": "sha256:abc123",
+        "downloaded_at": "2026-03-31T14:22:00Z",
+    }
+    defaults.update(overrides)
+    return ManifestEntry(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_missing_api_key_returns_401(self, client: TestClient):
+        resp = client.get("/models")
+        assert resp.status_code == 401
+
+    def test_wrong_api_key_returns_401(self, client: TestClient):
+        resp = client.get("/models", headers={"X-API-Key": "wrong"})
+        assert resp.status_code == 401
+
+    def test_correct_api_key_returns_200(self, client: TestClient):
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyState:
+    def test_no_manifest_returns_empty_list(self, client: TestClient):
+        """No models directory and no manifest → empty list, no error."""
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_empty_manifest_returns_empty_list(self, client: TestClient):
+        ensure_models_dir()
+        write_manifest(Manifest(models=[]))
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest-backed models
+# ---------------------------------------------------------------------------
+
+
+class TestManifestModels:
+    def test_single_manifest_entry(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(_make_entry())
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["name"] == "repo--iris-osl--v3"
+        assert entry["source_uri"] == "repo://iris-osl:v3"
+        assert entry["size_bytes"] == 4815162342
+        assert entry["checksum"] == "sha256:abc123"
+        assert entry["downloaded_at"] == "2026-03-31T14:22:00Z"
+        assert entry["in_manifest"] is True
+
+    def test_multiple_manifest_entries(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(
+            _make_entry(slug="repo--iris-osl--v3", source_uri="repo://iris-osl:v3")
+        )
+        add_manifest_entry(
+            _make_entry(
+                slug="hf--microsoft--phi-3",
+                source_uri="huggingface://microsoft/phi-3",
+                path="/opt/solar/models/hf--microsoft--phi-3",
+                size_bytes=7000000000,
+                digest=None,
+            )
+        )
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        names = {e["name"] for e in data}
+        assert names == {"repo--iris-osl--v3", "hf--microsoft--phi-3"}
+
+    def test_manifest_entry_without_digest(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(_make_entry(digest=None))
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["checksum"] is None
+
+    def test_path_comes_from_manifest(self, client: TestClient):
+        """The path in the response is taken from the manifest entry, not
+        derived from the current models dir."""
+        ensure_models_dir()
+        add_manifest_entry(_make_entry(path="/custom/absolute/path/to/model"))
+        resp = client.get("/models", headers=_headers())
+        assert resp.json()[0]["path"] == "/custom/absolute/path/to/model"
+
+
+# ---------------------------------------------------------------------------
+# Orphaned manifest entries (in manifest but directory missing)
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedManifestEntries:
+    def test_orphaned_entry_still_returned(self, client: TestClient):
+        """Manifest entry whose directory does not exist is returned with
+        in_manifest=True so callers can detect stale cache entries."""
+        ensure_models_dir()
+        add_manifest_entry(_make_entry())
+        # Do NOT create the directory — simulate orphaned entry.
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["in_manifest"] is True
+        assert data[0]["name"] == "repo--iris-osl--v3"
+
+
+# ---------------------------------------------------------------------------
+# Untracked directories (on disk but not in manifest)
+# ---------------------------------------------------------------------------
+
+
+class TestUntrackedDirectories:
+    def test_untracked_dir_is_included(self, client: TestClient, _isolated_env: Path):
+        ensure_models_dir()
+        # Manually create a model directory with a file.
+        model_dir = _isolated_env / "manually-placed-model"
+        model_dir.mkdir()
+        (model_dir / "model.gguf").write_bytes(b"x" * 512)
+
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["name"] == "manually-placed-model"
+        assert entry["in_manifest"] is False
+        assert entry["source_uri"] is None
+        assert entry["checksum"] is None
+        assert entry["size_bytes"] == 512
+
+    def test_untracked_dir_path_is_absolute(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / "some-model"
+        model_dir.mkdir()
+
+        resp = client.get("/models", headers=_headers())
+        data = resp.json()
+        assert Path(data[0]["path"]).is_absolute()
+
+    def test_files_in_models_dir_root_are_ignored(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Non-directory entries in MODELS_DIR (e.g. manifest.json) must not
+        appear in the response."""
+        ensure_models_dir()
+        # manifest.json is written by write_manifest; also add a stray file.
+        write_manifest(Manifest(models=[]))
+        (_isolated_env / "stray-file.txt").write_text("hello")
+
+        resp = client.get("/models", headers=_headers())
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Mixed: manifest + untracked
+# ---------------------------------------------------------------------------
+
+
+class TestMixed:
+    def test_manifest_and_untracked_both_returned(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        # Tracked model (manifest entry, directory present).
+        tracked_dir = _isolated_env / "repo--iris-osl--v3"
+        tracked_dir.mkdir()
+        add_manifest_entry(
+            _make_entry(
+                path=str(tracked_dir.resolve()),
+                size_bytes=100,
+            )
+        )
+        # Untracked model (directory only, no manifest entry).
+        untracked_dir = _isolated_env / "manually-placed"
+        untracked_dir.mkdir()
+        (untracked_dir / "weights.bin").write_bytes(b"\x00" * 256)
+
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+        by_name = {e["name"]: e for e in data}
+        assert "repo--iris-osl--v3" in by_name
+        assert "manually-placed" in by_name
+
+        tracked = by_name["repo--iris-osl--v3"]
+        assert tracked["in_manifest"] is True
+        assert tracked["size_bytes"] == 100  # from manifest
+
+        untracked = by_name["manually-placed"]
+        assert untracked["in_manifest"] is False
+        assert untracked["size_bytes"] == 256  # computed from disk
+
+    def test_manifest_entry_takes_priority_over_disk_for_size(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """When a directory exists AND has a manifest entry, the size from
+        the manifest is used (not recomputed from disk)."""
+        ensure_models_dir()
+        model_dir = _isolated_env / "repo--iris-osl--v3"
+        model_dir.mkdir()
+        (model_dir / "model.bin").write_bytes(b"\x00" * 64)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve()), size_bytes=9999))
+
+        resp = client.get("/models", headers=_headers())
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["size_bytes"] == 9999  # manifest wins


### PR DESCRIPTION
## Description
Exposes the managed models directory via a REST API so that Solar Control (S-012 HuggingFace resolver, S-019 distribution, S-020 availability query) can programmatically discover which models are present on a host without SSH access.
## Changes
- New `solar_host/routes/models.py`: `ModelEntry` response schema and `GET /models` endpoint. Combines manifest-tracked models with untracked subdirectories; orphaned manifest entries (directory deleted) are also surfaced.
- `solar_host/main.py`: register `models.router` under `/models`.
- `tests/test_routes_models.py`: 15 tests covering auth, empty state, manifest models, orphaned entries, untracked directories, and mixed scenarios.
## Related Issues
Closes #11