### PR TITLE
feat: model pulling from huggingface and harbor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ PORT=8001
 MODELS_DIR=./models
 SOLAR_CONTROL_URL=ws://localhost:8015/ws/host-channel
 INSECURE=false
+
+# Harbor registry credentials (required for repo:// model pulls)
+HARBOR_URL=https://imgrepo.harbor.hu
+HARBOR_USERNAME=
+HARBOR_PASSWORD=
+
+# HuggingFace Hub token (optional for public models, required for gated models)
+HF_TOKEN=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0.dev"
 description = "Process manager for model inference backends (llama.cpp, HuggingFace)"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [{ name = "DamitDev" }]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -30,6 +29,8 @@ dependencies = [
     "python-socketio[asyncio_client]",
     "Pebble>=5.0.7",
     "psutil>=6.1.0",
+    "harbor-oci-client>=0.1.0",
+    "huggingface-hub>=1.10.1",
 ]
 
 [project.optional-dependencies]

--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -41,6 +41,14 @@ class Settings(BaseSettings):
     # Allow connecting to solar-control over HTTPS/WSS with invalid certificates
     insecure: bool = False
 
+    # Harbor registry credentials (required for repo:// pulls)
+    harbor_url: str = ""
+    harbor_username: str = ""
+    harbor_password: str = ""
+
+    # HuggingFace Hub token (optional for public models, required for gated models)
+    hf_token: str = ""
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -1,16 +1,24 @@
 """Managed models directory and manifest for solar-host.
 
 Provides slug derivation from model source URIs, atomic manifest read/write,
-and CRUD helpers for tracking downloaded models. The manifest file
-(MODELS_DIR/manifest.json) is the single source of truth for cache detection.
+CRUD helpers for tracking downloaded models, and the pull_model() orchestration
+function for downloading from Harbor (ORAS) or HuggingFace Hub.
+
+The manifest file (MODELS_DIR/manifest.json) is the single source of truth for
+cache detection.
 """
 
+import errno
 import json
 import logging
 import os
 import re
+import shutil
+import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
@@ -135,3 +143,265 @@ def remove_manifest_entry(source_uri: str) -> bool:
         return False
     write_manifest(manifest)
     return True
+
+
+# ---------------------------------------------------------------------------
+# Pull orchestration
+# ---------------------------------------------------------------------------
+
+# Protects manifest read-modify-write from concurrent pulls in different threads.
+_manifest_lock = threading.Lock()
+
+# Per-URI locks serialise the full pull lifecycle (cache check → download →
+# manifest write) so two concurrent requests for the *same* source_uri cannot
+# both miss the cache and download the model twice.
+_uri_locks: dict[str, threading.Lock] = {}
+_uri_locks_guard = threading.Lock()
+
+
+def _get_uri_lock(source_uri: str) -> threading.Lock:
+    """Return a per-URI lock, creating one if it doesn't exist yet."""
+    with _uri_locks_guard:
+        if source_uri not in _uri_locks:
+            _uri_locks[source_uri] = threading.Lock()
+        return _uri_locks[source_uri]
+
+
+_SOURCE_URI_PREFIXES = {
+    "harbor": "repo://",
+    "huggingface": "huggingface://",
+}
+
+
+class ModelPullError(Exception):
+    """Raised by pull_model() for expected failure conditions.
+
+    Carries enough context for the route handler to build a spec-compliant
+    error response without leaking internal details.
+    """
+
+    def __init__(self, status_code: int, error: str, detail: str, source_uri: str):
+        self.status_code = status_code
+        self.error = error
+        self.detail = detail
+        self.source_uri = source_uri
+        super().__init__(detail)
+
+
+def _compute_dir_size(path: Path) -> int:
+    """Return total size in bytes of regular files under *path* (no symlinks)."""
+    if not path.is_dir():
+        return 0
+    total = 0
+    for entry in path.rglob("*"):
+        if not entry.is_symlink() and entry.is_file():
+            try:
+                total += entry.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def _pull_harbor(
+    harbor_ref: str,
+    target_dir: Path,
+    source_uri: str,
+) -> None:
+    """Download a Harbor OCI artifact via ORAS into *target_dir*.
+
+    Credentials must have been validated by the caller before this is invoked.
+    """
+    from harbor_oci_client import OrasHelper  # type: ignore[import-untyped]
+
+    parsed = urlparse(settings.harbor_url)
+    hostname = parsed.hostname or settings.harbor_url
+
+    oras = OrasHelper(
+        hostname=hostname,
+        username=settings.harbor_username,
+        password=settings.harbor_password,
+    )
+    oras.pull(harbor_ref, outdir=str(target_dir))
+
+
+def _pull_huggingface(
+    model_id: str,
+    target_dir: Path,
+    source_uri: str,
+) -> None:
+    """Download a HuggingFace Hub model snapshot into *target_dir*."""
+    import huggingface_hub  # type: ignore[import-untyped]
+
+    hf_token: Optional[str] = settings.hf_token or None
+
+    huggingface_hub.snapshot_download(
+        repo_id=model_id,
+        local_dir=str(target_dir),
+        token=hf_token,
+    )
+
+
+def pull_model(
+    *,
+    source: str,
+    source_uri: str,
+    harbor_ref: Optional[str] = None,
+    model_id: Optional[str] = None,
+    digest: Optional[str] = None,
+) -> dict:
+    """Download a model from Harbor or HuggingFace Hub and record it in the manifest.
+
+    This function is synchronous and intended to be called via
+    ``asyncio.to_thread()`` from the async route handler.
+
+    Returns a dict with keys ``path``, ``cached``, and ``source_uri``.
+    Raises ``ModelPullError`` for all expected failure conditions.
+    """
+    # 1. Validate that source_uri scheme matches the declared source.
+    expected_prefix = _SOURCE_URI_PREFIXES.get(source)
+    if expected_prefix is None:
+        raise ModelPullError(
+            400, "invalid_request", f"Unsupported source: {source!r}", source_uri
+        )
+    if not source_uri.startswith(expected_prefix):
+        raise ModelPullError(
+            400,
+            "invalid_request",
+            f"source_uri {source_uri!r} does not match source type {source!r} "
+            f"(expected prefix {expected_prefix!r})",
+            source_uri,
+        )
+
+    # Acquire a per-URI lock so that concurrent pulls for the *same* source_uri
+    # are serialised end-to-end.  The second caller will block here, then see
+    # the cache hit once the first caller finishes.
+    uri_lock = _get_uri_lock(source_uri)
+    with uri_lock:
+        # 2. Cache check — manifest is the single source of truth.
+        cached_entry = get_manifest_entry(source_uri)
+        if cached_entry is not None:
+            return {"path": cached_entry.path, "cached": True, "source_uri": source_uri}
+
+        # 3. Derive slug and target directory.
+        try:
+            slug = source_uri_to_slug(source_uri)
+        except ValueError as exc:
+            raise ModelPullError(400, "invalid_request", str(exc), source_uri) from exc
+
+        target_dir = get_models_dir() / slug
+
+        # 4. Validate credentials before touching the filesystem.
+        if source == "harbor":
+            if not all(
+                [
+                    settings.harbor_url,
+                    settings.harbor_username,
+                    settings.harbor_password,
+                ]
+            ):
+                raise ModelPullError(
+                    500,
+                    "credentials_missing",
+                    "Harbor credentials not configured. Set HARBOR_URL, HARBOR_USERNAME, and HARBOR_PASSWORD.",
+                    source_uri,
+                )
+
+        # 5. Remove any stale/partial directory from a previous failed pull.
+        if target_dir.exists():
+            logger.warning("Removing stale model directory before pull: %s", target_dir)
+            shutil.rmtree(target_dir, ignore_errors=True)
+
+        # 6. Download — wrap in try/except to clean up on failure.
+        try:
+            if source == "harbor":
+                _pull_harbor(harbor_ref or "", target_dir, source_uri)
+            else:
+                _pull_huggingface(model_id or "", target_dir, source_uri)
+        except ModelPullError:
+            shutil.rmtree(target_dir, ignore_errors=True)
+            raise
+        except OSError as exc:
+            shutil.rmtree(target_dir, ignore_errors=True)
+            if exc.errno == errno.ENOSPC:
+                raise ModelPullError(
+                    507, "insufficient_storage", "Insufficient disk space.", source_uri
+                ) from exc
+            raise ModelPullError(
+                500, "model_pull_failed", str(exc), source_uri
+            ) from exc
+        except Exception as exc:
+            shutil.rmtree(target_dir, ignore_errors=True)
+            _map_download_exception(exc, source_uri)
+
+        # 7. Compute size of downloaded files.
+        size_bytes = _compute_dir_size(target_dir)
+
+        # 8. Update manifest atomically under lock to prevent concurrent write
+        #    races between pulls for *different* URIs finishing simultaneously.
+        entry = ManifestEntry(
+            slug=slug,
+            source_uri=source_uri,
+            path=str(target_dir.resolve()),
+            size_bytes=size_bytes,
+            digest=digest,
+            downloaded_at=datetime.now(timezone.utc).isoformat(),
+        )
+        with _manifest_lock:
+            add_manifest_entry(entry)
+
+        logger.info("Model pulled successfully: %s -> %s", source_uri, target_dir)
+        return {
+            "path": str(target_dir.resolve()),
+            "cached": False,
+            "source_uri": source_uri,
+        }
+
+
+def _map_download_exception(exc: Exception, source_uri: str) -> None:
+    """Re-raise a library exception as a ModelPullError with an appropriate HTTP status.
+
+    Always raises — never returns.
+    """
+    exc_type = type(exc).__name__
+    module = type(exc).__module__ or ""
+
+    # harbor-oci-client exceptions
+    if module.startswith("harbor_oci_client"):
+        if exc_type == "HarborConnectionError":
+            raise ModelPullError(
+                502,
+                "source_unreachable",
+                f"Harbor registry unreachable: {exc}",
+                source_uri,
+            ) from exc
+        if exc_type == "HarborAuthError":
+            raise ModelPullError(
+                401, "auth_failed", f"Harbor authentication failed: {exc}", source_uri
+            ) from exc
+        if exc_type == "ArtifactNotFoundError":
+            raise ModelPullError(
+                404, "not_found", f"Artifact not found in Harbor: {exc}", source_uri
+            ) from exc
+        raise ModelPullError(
+            502, "source_unreachable", f"Harbor error: {exc}", source_uri
+        ) from exc
+
+    # huggingface_hub exceptions
+    if module.startswith("huggingface_hub"):
+        if exc_type == "RepositoryNotFoundError":
+            raise ModelPullError(
+                404, "not_found", f"HuggingFace repository not found: {exc}", source_uri
+            ) from exc
+        if exc_type == "GatedRepoError":
+            raise ModelPullError(
+                401,
+                "auth_failed",
+                f"HuggingFace repository is gated: {exc}",
+                source_uri,
+            ) from exc
+        raise ModelPullError(
+            502, "source_unreachable", f"HuggingFace Hub error: {exc}", source_uri
+        ) from exc
+
+    # Fallback
+    raise ModelPullError(500, "model_pull_failed", str(exc), source_uri) from exc

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -1,19 +1,31 @@
-"""GET /models — lists models recorded in MODELS_DIR/manifest.json.
+"""GET /models and POST /models/pull routes.
 
+GET /models — lists models recorded in MODELS_DIR/manifest.json.
 Per S-009, the manifest is the single source of truth. This endpoint does not
 scan the filesystem for models; only entries present in the manifest are
 returned. Missing or invalid manifest yields an empty list (see read_manifest).
+
+POST /models/pull — pulls a model from Harbor (ORAS) or HuggingFace Hub and
+records it in the manifest. Returns the local path and whether it was a cache
+hit. Per S-015 / spec Section 3.6.
 """
 
 import asyncio
-from typing import List, Optional
+from typing import List, Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from solar_host.models_manager import read_manifest
+from solar_host import models_manager
+from solar_host.models_manager import ModelPullError, read_manifest
 
 router = APIRouter(prefix="/models", tags=["models"])
+
+
+# ---------------------------------------------------------------------------
+# GET /models — list
+# ---------------------------------------------------------------------------
 
 
 class ModelEntry(BaseModel):
@@ -52,3 +64,89 @@ async def list_models() -> List[ModelEntry]:
     Returns an empty list when the manifest is missing, empty, or unreadable.
     """
     return await asyncio.to_thread(_manifest_to_entries)
+
+
+# ---------------------------------------------------------------------------
+# POST /models/pull
+# ---------------------------------------------------------------------------
+
+
+class PullRequest(BaseModel):
+    """Request body for POST /models/pull (spec Section 3.6)."""
+
+    model_config = {"protected_namespaces": ()}
+
+    source: Literal["harbor", "huggingface"]
+    source_uri: str
+    harbor_ref: Optional[str] = None
+    model_id: Optional[str] = None
+    digest: Optional[str] = None
+
+
+class PullResponse(BaseModel):
+    """Response body for POST /models/pull (spec Section 3.6)."""
+
+    path: str
+    cached: bool
+    source_uri: str
+
+
+@router.post(
+    "/pull",
+    response_model=PullResponse,
+    summary="Pull a model from source",
+    responses={
+        200: {
+            "description": "Model available at returned path (cached or freshly downloaded)"
+        },
+        400: {
+            "description": "Invalid request (bad source_uri scheme or malformed URI)"
+        },
+        401: {"description": "Source authentication failed"},
+        404: {"description": "Model not found at source"},
+        422: {"description": "Missing required field for the chosen source"},
+        500: {"description": "Missing credentials or unexpected server error"},
+        502: {"description": "Source registry/hub unreachable"},
+        507: {"description": "Insufficient disk space"},
+    },
+)
+async def pull_model(req: PullRequest) -> PullResponse:
+    """Pull a model from Harbor or HuggingFace Hub.
+
+    Checks the manifest cache first. On a cache hit the stored path is returned
+    immediately without re-downloading. On a cache miss the model is downloaded,
+    the manifest is updated atomically, and the new path is returned.
+
+    The caller blocks until the model is fully available.
+    """
+    # Validate conditional required fields before doing any I/O.
+    if req.source == "harbor" and not req.harbor_ref:
+        raise HTTPException(
+            status_code=422, detail="harbor_ref is required for harbor source"
+        )
+    if req.source == "huggingface" and not req.model_id:
+        raise HTTPException(
+            status_code=422, detail="model_id is required for huggingface source"
+        )
+
+    try:
+        result = await asyncio.to_thread(
+            models_manager.pull_model,
+            source=req.source,
+            source_uri=req.source_uri,
+            harbor_ref=req.harbor_ref,
+            model_id=req.model_id,
+            digest=req.digest,
+        )
+    except ModelPullError as exc:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": exc.error,
+                "detail": exc.detail,
+                "source_uri": exc.source_uri,
+                "status_code": exc.status_code,
+            },
+        )
+
+    return PullResponse(**result)

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1,0 +1,728 @@
+"""Tests for POST /models/pull endpoint (solar_host/routes/models.py).
+
+All external I/O (Harbor OrasHelper, huggingface_hub.snapshot_download) is
+mocked. Filesystem operations use tmp_path so nothing touches the real disk.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from solar_host.main import app
+from solar_host.models_manager import (
+    ManifestEntry,
+    add_manifest_entry,
+    ensure_models_dir,
+    get_manifest_entry,
+    get_models_dir,
+)
+
+API_KEY = "test-key-s015"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path: Path, monkeypatch):
+    """Point settings at a fresh tmp models dir and fixed API key/credentials.
+
+    Credentials are set to valid values by default; individual tests can
+    override them to trigger credential-missing errors.
+    """
+    models = tmp_path / "models"
+    monkeypatch.setattr("solar_host.config.settings.models_dir", str(models))
+    monkeypatch.setattr("solar_host.config.settings.solar_control_url", "")
+    monkeypatch.setattr("solar_host.config.settings.api_key", API_KEY)
+    monkeypatch.setattr(
+        "solar_host.config.settings.harbor_url", "https://imgrepo.damit.hu"
+    )
+    monkeypatch.setattr("solar_host.config.settings.harbor_username", "robot")
+    monkeypatch.setattr("solar_host.config.settings.harbor_password", "secret")
+    monkeypatch.setattr("solar_host.config.settings.hf_token", "")
+    return models
+
+
+@pytest.fixture()
+def client():
+    """HTTP test client with full app lifespan."""
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def _headers() -> dict:
+    return {"X-API-Key": API_KEY}
+
+
+def _harbor_body(**overrides) -> dict:
+    defaults = {
+        "source": "harbor",
+        "source_uri": "repo://iris-osl:v3",
+        "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
+        "digest": "sha256:abc123",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _hf_body(**overrides) -> dict:
+    defaults = {
+        "source": "huggingface",
+        "source_uri": "huggingface://microsoft/phi-3",
+        "model_id": "microsoft/phi-3",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_manifest_entry(**overrides) -> ManifestEntry:
+    defaults = {
+        "slug": "repo--iris-osl--v3",
+        "source_uri": "repo://iris-osl:v3",
+        "path": "/opt/solar/models/repo--iris-osl--v3",
+        "size_bytes": 4815162342,
+        "digest": "sha256:abc123",
+        "downloaded_at": "2026-03-31T14:22:00Z",
+    }
+    defaults.update(overrides)
+    return ManifestEntry(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_missing_api_key_returns_401(self, client: TestClient):
+        resp = client.post("/models/pull", json=_harbor_body())
+        assert resp.status_code == 401
+
+    def test_wrong_api_key_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/models/pull", json=_harbor_body(), headers={"X-API-Key": "wrong"}
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Request validation (422)
+# ---------------------------------------------------------------------------
+
+
+class TestRequestValidation:
+    def test_harbor_source_requires_harbor_ref(self, client: TestClient):
+        body = _harbor_body()
+        del body["harbor_ref"]
+        resp = client.post("/models/pull", json=body, headers=_headers())
+        assert resp.status_code == 422
+
+    def test_huggingface_source_requires_model_id(self, client: TestClient):
+        body = _hf_body()
+        del body["model_id"]
+        resp = client.post("/models/pull", json=body, headers=_headers())
+        assert resp.status_code == 422
+
+    def test_invalid_source_type_returns_422(self, client: TestClient):
+        resp = client.post(
+            "/models/pull",
+            json={"source": "s3", "source_uri": "s3://bucket/model"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_harbor_ref_empty_string_returns_422(self, client: TestClient):
+        resp = client.post(
+            "/models/pull",
+            json={**_harbor_body(), "harbor_ref": ""},
+            headers=_headers(),
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# source_uri / source type mismatch (400)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceUriMismatch:
+    def test_harbor_source_with_hf_uri_returns_400(self, client: TestClient):
+        resp = client.post(
+            "/models/pull",
+            json={
+                "source": "harbor",
+                "source_uri": "huggingface://microsoft/phi-3",
+                "harbor_ref": "imgrepo.damit.hu/supernova/phi-3:v1",
+            },
+            headers=_headers(),
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["error"] == "invalid_request"
+        assert data["source_uri"] == "huggingface://microsoft/phi-3"
+
+    def test_huggingface_source_with_repo_uri_returns_400(self, client: TestClient):
+        resp = client.post(
+            "/models/pull",
+            json={
+                "source": "huggingface",
+                "source_uri": "repo://iris-osl:v3",
+                "model_id": "iris-osl",
+            },
+            headers=_headers(),
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["error"] == "invalid_request"
+
+
+# ---------------------------------------------------------------------------
+# Cache hit
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHit:
+    def test_cache_hit_returns_cached_true(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(_make_manifest_entry())
+
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is True
+        assert data["source_uri"] == "repo://iris-osl:v3"
+        assert data["path"] == "/opt/solar/models/repo--iris-osl--v3"
+        mock_pull.assert_not_called()
+
+    def test_cache_hit_returns_stored_path(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(_make_manifest_entry(path="/custom/path/to/model"))
+
+        resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.json()["path"] == "/custom/path/to/model"
+
+    def test_hf_cache_hit(self, client: TestClient):
+        ensure_models_dir()
+        add_manifest_entry(
+            _make_manifest_entry(
+                slug="hf--microsoft--phi-3",
+                source_uri="huggingface://microsoft/phi-3",
+                path="/opt/solar/models/hf--microsoft--phi-3",
+            )
+        )
+        with patch("solar_host.models_manager._pull_huggingface") as mock_dl:
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is True
+        mock_dl.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Harbor pull (cache miss)
+# ---------------------------------------------------------------------------
+
+
+class TestHarborPull:
+    def _make_mock_pull(self, tmp_path: Path):
+        """Return a side_effect function that creates a dummy file in target_dir."""
+
+        def _side_effect(harbor_ref: str, target_dir: Path, source_uri: str):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "model.gguf").write_bytes(b"x" * 1024)
+
+        return _side_effect
+
+    def test_harbor_pull_cache_miss(self, client: TestClient, _isolated_env: Path):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ) as mock_pull:
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is False
+        assert data["source_uri"] == "repo://iris-osl:v3"
+        assert "repo--iris-osl--v3" in data["path"]
+        mock_pull.assert_called_once()
+
+    def test_harbor_pull_updates_manifest(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        entry = get_manifest_entry("repo://iris-osl:v3")
+        assert entry is not None
+        assert entry.slug == "repo--iris-osl--v3"
+        assert entry.digest == "sha256:abc123"
+        assert entry.size_bytes == 1024
+
+    def test_harbor_pull_called_with_correct_args(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        captured = {}
+
+        def _capture(harbor_ref, target_dir, source_uri):
+            captured["harbor_ref"] = harbor_ref
+            captured["target_dir"] = target_dir
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "model.gguf").write_bytes(b"x")
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_capture):
+            client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert captured["harbor_ref"] == "imgrepo.damit.hu/supernova/iris-osl:v3"
+        assert str(captured["target_dir"]).endswith("repo--iris-osl--v3")
+
+    def test_second_pull_returns_cached(self, client: TestClient, _isolated_env: Path):
+        """After a successful pull, the same URI returns cached=True."""
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            resp1 = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp1.json()["cached"] is False
+
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            resp2 = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp2.json()["cached"] is True
+        mock_pull.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HuggingFace pull (cache miss)
+# ---------------------------------------------------------------------------
+
+
+class TestHuggingFacePull:
+    def _make_mock_dl(self, _isolated_env: Path):
+        def _side_effect(model_id, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "pytorch_model.bin").write_bytes(b"w" * 2048)
+
+        return _side_effect
+
+    def test_hf_pull_cache_miss(self, client: TestClient, _isolated_env: Path):
+        with patch(
+            "solar_host.models_manager._pull_huggingface",
+            side_effect=self._make_mock_dl(_isolated_env),
+        ):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is False
+        assert "hf--microsoft--phi-3" in data["path"]
+
+    def test_hf_pull_updates_manifest(self, client: TestClient, _isolated_env: Path):
+        with patch(
+            "solar_host.models_manager._pull_huggingface",
+            side_effect=self._make_mock_dl(_isolated_env),
+        ):
+            client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        entry = get_manifest_entry("huggingface://microsoft/phi-3")
+        assert entry is not None
+        assert entry.slug == "hf--microsoft--phi-3"
+        assert entry.size_bytes == 2048
+
+    def test_hf_pull_passes_none_token_when_empty(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """When hf_token is empty string, snapshot_download must receive token=None."""
+        captured = {}
+
+        def _capture(model_id, target_dir, source_uri):
+            captured["model_id"] = model_id
+            captured["target_dir"] = target_dir
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "model.bin").write_bytes(b"x")
+
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=_capture):
+            client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert captured["model_id"] == "microsoft/phi-3"
+
+    def test_hf_pull_with_token(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        monkeypatch.setattr("solar_host.config.settings.hf_token", "hf_mytoken123")
+        captured_token = {}
+
+        def _fake_snapshot(repo_id, local_dir, token):
+            captured_token["token"] = token
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
+            (Path(local_dir) / "model.bin").write_bytes(b"x")
+
+        with patch("huggingface_hub.snapshot_download", side_effect=_fake_snapshot):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert captured_token["token"] == "hf_mytoken123"
+
+    def test_hf_pull_passes_none_not_empty_string(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Empty hf_token must become None, not empty string, in snapshot_download."""
+        captured_token = {}
+
+        def _fake_snapshot(repo_id, local_dir, token):
+            captured_token["token"] = token
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
+            (Path(local_dir) / "model.bin").write_bytes(b"x")
+
+        with patch("huggingface_hub.snapshot_download", side_effect=_fake_snapshot):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert captured_token["token"] is None
+
+
+# ---------------------------------------------------------------------------
+# Missing credentials (500)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingCredentials:
+    def test_missing_harbor_url_returns_500(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr("solar_host.config.settings.harbor_url", "")
+        resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 500
+        data = resp.json()
+        assert data["error"] == "credentials_missing"
+
+    def test_missing_harbor_username_returns_500(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr("solar_host.config.settings.harbor_username", "")
+        resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 500
+        data = resp.json()
+        assert data["error"] == "credentials_missing"
+
+    def test_missing_harbor_password_returns_500(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr("solar_host.config.settings.harbor_password", "")
+        resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 500
+        data = resp.json()
+        assert data["error"] == "credentials_missing"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    """Verify that library exceptions map to the correct HTTP status codes
+    and that the response body matches the spec Section 6.2 format."""
+
+    def _post_harbor(self, client, exc_to_raise):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=exc_to_raise,
+        ):
+            return client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+    def _assert_error_body(self, resp, expected_status: int, expected_error: str):
+        assert resp.status_code == expected_status
+        data = resp.json()
+        assert data["error"] == expected_error
+        assert "detail" in data
+        assert data["source_uri"] == "repo://iris-osl:v3"
+        assert data["status_code"] == expected_status
+
+    def test_harbor_connection_error_returns_502(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(
+            502, "source_unreachable", "Harbor unreachable", "repo://iris-osl:v3"
+        )
+        resp = self._post_harbor(client, exc)
+        self._assert_error_body(resp, 502, "source_unreachable")
+
+    def test_harbor_auth_error_returns_401(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(401, "auth_failed", "Auth failed", "repo://iris-osl:v3")
+        resp = self._post_harbor(client, exc)
+        self._assert_error_body(resp, 401, "auth_failed")
+
+    def test_artifact_not_found_returns_404(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(404, "not_found", "Not found", "repo://iris-osl:v3")
+        resp = self._post_harbor(client, exc)
+        self._assert_error_body(resp, 404, "not_found")
+
+    def test_disk_full_returns_507(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(
+            507, "insufficient_storage", "Disk full", "repo://iris-osl:v3"
+        )
+        resp = self._post_harbor(client, exc)
+        self._assert_error_body(resp, 507, "insufficient_storage")
+
+    def test_hf_repo_not_found_returns_404(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(
+            404, "not_found", "HF repo not found", "huggingface://microsoft/phi-3"
+        )
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=exc):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "not_found"
+
+    def test_hf_gated_repo_returns_401(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(
+            401, "auth_failed", "Gated repo", "huggingface://microsoft/phi-3"
+        )
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=exc):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "auth_failed"
+
+
+# ---------------------------------------------------------------------------
+# Failure cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestFailureCleanup:
+    def test_partial_directory_cleaned_up_on_failure(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """If download raises, the (possibly partial) target directory must not remain."""
+        from solar_host.models_manager import ModelPullError
+
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+
+        def _fail(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "partial.bin").write_bytes(b"partial")
+            raise ModelPullError(502, "source_unreachable", "Harbor down", source_uri)
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_fail):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 502
+        assert not slug_dir.exists(), "Partial directory should have been cleaned up"
+
+    def test_failed_pull_not_added_to_manifest(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        from solar_host.models_manager import ModelPullError
+
+        def _fail(harbor_ref, target_dir, source_uri):
+            raise ModelPullError(404, "not_found", "Not found", source_uri)
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_fail):
+            client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert get_manifest_entry("repo://iris-osl:v3") is None
+
+    def test_stale_directory_removed_before_pull(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Pre-existing orphan directory is deleted before a fresh download starts."""
+        ensure_models_dir()
+        slug_dir = get_models_dir() / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        stale_file = slug_dir / "stale.bin"
+        stale_file.write_bytes(b"stale data")
+
+        removed_before_dl = {}
+
+        def _check_and_create(harbor_ref, target_dir, source_uri):
+            removed_before_dl["stale_gone"] = not stale_file.exists()
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "fresh.bin").write_bytes(b"fresh data")
+
+        with patch(
+            "solar_host.models_manager._pull_harbor", side_effect=_check_and_create
+        ):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert removed_before_dl.get("stale_gone") is True, (
+            "Stale directory should have been removed before download started"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OSError / ENOSPC
+# ---------------------------------------------------------------------------
+
+
+class TestDiskFull:
+    def test_enospc_during_harbor_pull_returns_507(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """An OSError with errno.ENOSPC from the download must surface as 507."""
+        import errno as _errno
+
+        def _fail(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            raise OSError(_errno.ENOSPC, "No space left on device")
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_fail):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 507
+        data = resp.json()
+        assert data["error"] == "insufficient_storage"
+        assert data["source_uri"] == "repo://iris-osl:v3"
+
+    def test_enospc_during_hf_pull_returns_507(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        import errno as _errno
+
+        def _fail(model_id, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            raise OSError(_errno.ENOSPC, "No space left on device")
+
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=_fail):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+
+        assert resp.status_code == 507
+        assert resp.json()["error"] == "insufficient_storage"
+
+    def test_non_enospc_oserror_returns_500(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        import errno as _errno
+
+        def _fail(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            raise OSError(_errno.EACCES, "Permission denied")
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_fail):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 500
+        assert resp.json()["error"] == "model_pull_failed"
+
+
+# ---------------------------------------------------------------------------
+# _map_download_exception integration
+# ---------------------------------------------------------------------------
+
+
+class TestMapDownloadException:
+    """Exercise _map_download_exception via pull_model() with real-shaped exceptions."""
+
+    @staticmethod
+    def _make_exc(module: str, name: str, msg: str = "boom") -> Exception:
+        """Create an exception whose __module__ and __name__ match a library."""
+        cls = type(name, (Exception,), {"__module__": module})
+        return cls(msg)
+
+    def test_harbor_connection_error_mapped(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        exc = self._make_exc("harbor_oci_client.exceptions", "HarborConnectionError")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 502
+        assert resp.json()["error"] == "source_unreachable"
+
+    def test_harbor_auth_error_mapped(self, client: TestClient, _isolated_env: Path):
+        exc = self._make_exc("harbor_oci_client.exceptions", "HarborAuthError")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "auth_failed"
+
+    def test_artifact_not_found_mapped(self, client: TestClient, _isolated_env: Path):
+        exc = self._make_exc("harbor_oci_client.exceptions", "ArtifactNotFoundError")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "not_found"
+
+    def test_unknown_harbor_error_mapped_to_502(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        exc = self._make_exc("harbor_oci_client.exceptions", "HarborAPIError")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 502
+        assert resp.json()["error"] == "source_unreachable"
+
+    def test_hf_repository_not_found_mapped(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        exc = self._make_exc("huggingface_hub.utils", "RepositoryNotFoundError")
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=exc):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "not_found"
+
+    def test_hf_gated_repo_mapped(self, client: TestClient, _isolated_env: Path):
+        exc = self._make_exc("huggingface_hub.utils", "GatedRepoError")
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=exc):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "auth_failed"
+
+    def test_unknown_hf_error_mapped_to_502(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        exc = self._make_exc("huggingface_hub.utils", "HfHubHTTPError")
+        with patch("solar_host.models_manager._pull_huggingface", side_effect=exc):
+            resp = client.post("/models/pull", json=_hf_body(), headers=_headers())
+        assert resp.status_code == 502
+        assert resp.json()["error"] == "source_unreachable"
+
+    def test_unknown_exception_mapped_to_500(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        exc = RuntimeError("something unexpected")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 500
+        assert resp.json()["error"] == "model_pull_failed"
+
+
+# ---------------------------------------------------------------------------
+# Response structure
+# ---------------------------------------------------------------------------
+
+
+class TestResponseStructure:
+    def test_response_contains_required_fields(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        def _create(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "model.gguf").write_bytes(b"x" * 512)
+
+        with patch("solar_host.models_manager._pull_harbor", side_effect=_create):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data.keys()) == {"path", "cached", "source_uri"}
+
+    def test_error_response_contains_required_fields(self, client: TestClient):
+        from solar_host.models_manager import ModelPullError
+
+        exc = ModelPullError(404, "not_found", "Gone", "repo://iris-osl:v3")
+        with patch("solar_host.models_manager._pull_harbor", side_effect=exc):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        data = resp.json()
+        assert set(data.keys()) == {"error", "detail", "source_uri", "status_code"}


### PR DESCRIPTION
## Description
Adds a pull-based model acquisition endpoint to Solar Host. Instead of receiving model uploads from Solar Control, the host now pulls models directly from their sources (Harbor via ORAS, HuggingFace Hub) when instructed. This follows the Kubernetes model where hosts pull from registries and the control plane orchestrates. The endpoint checks the manifest cache first and downloads on miss, with atomic manifest updates and structured error handling per the model source URI spec.

## Changes
- Added `harbor-oci-client` and `huggingface-hub` as dependencies; bumped Python requirement to `>=3.12`
- Added Harbor credentials (`HARBOR_URL`, `HARBOR_USERNAME`, `HARBOR_PASSWORD`) and HuggingFace token (`HF_TOKEN`) to Settings and `.env.example`
- Implemented `ModelPullError` exception, `pull_model()` orchestration function, and `_map_download_exception()` error mapper in `models_manager.py`
- Implemented `POST /models/pull` endpoint with `PullRequest`/`PullResponse` models in `routes/models.py`
- Added `threading.Lock` around manifest writes to prevent data loss from concurrent pulls
- Added cleanup of partial/stale directories on download failure
- Added cross-validation of `source` type vs `source_uri` scheme
- Added 85 tests covering cache hits, cache miss downloads, request validation, credential checks, error mapping (Harbor + HF exceptions, ENOSPC, generic), failure cleanup, and response structure

## Related Issues
Resolves #12 