### PR TITLE
feat: implement DELETE /models/{name} endpoint

### DIFF
--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -145,12 +145,64 @@ def remove_manifest_entry(source_uri: str) -> bool:
     return True
 
 
+def get_manifest_entry_by_slug(slug: str) -> Optional[ManifestEntry]:
+    """Look up a manifest entry by slug. Returns None if not found."""
+    manifest = read_manifest()
+    for entry in manifest.models:
+        if entry.slug == slug:
+            return entry
+    return None
+
+
+def delete_model_files(path: str) -> None:
+    """Remove model files from disk.
+
+    Handles both directory and single-file models. Silently succeeds if the
+    path no longer exists (e.g. already manually removed).
+    """
+    model_path = Path(path)
+    try:
+        if model_path.is_dir():
+            shutil.rmtree(model_path, ignore_errors=False)
+        elif model_path.exists():
+            model_path.unlink()
+        # If it does not exist at all, nothing to do.
+    except FileNotFoundError:
+        logger.warning("Model path already gone during deletion: %s", path)
+    except OSError as exc:
+        logger.error("Failed to delete model files at %s: %s", path, exc)
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Pull orchestration
 # ---------------------------------------------------------------------------
 
 # Protects manifest read-modify-write from concurrent pulls in different threads.
 _manifest_lock = threading.Lock()
+
+
+def remove_manifest_entry_by_slug(slug: str) -> Optional[ManifestEntry]:
+    """Remove a manifest entry by slug under the manifest lock.
+
+    Returns the removed entry (so the caller can obtain the path to delete
+    from disk), or None if no entry matched.
+    """
+    with _manifest_lock:
+        manifest = read_manifest()
+        removed: Optional[ManifestEntry] = None
+        new_models = []
+        for entry in manifest.models:
+            if entry.slug == slug and removed is None:
+                removed = entry
+            else:
+                new_models.append(entry)
+        if removed is None:
+            return None
+        manifest.models = new_models
+        write_manifest(manifest)
+        return removed
+
 
 # Per-URI locks serialise the full pull lifecycle (cache check → download →
 # manifest write) so two concurrent requests for the *same* source_uri cannot

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -1,4 +1,4 @@
-"""GET /models and POST /models/pull routes.
+"""GET /models, POST /models/pull, and DELETE /models/{name} routes.
 
 GET /models — lists models recorded in MODELS_DIR/manifest.json.
 Per S-009, the manifest is the single source of truth. This endpoint does not
@@ -8,16 +8,23 @@ returned. Missing or invalid manifest yields an empty list (see read_manifest).
 POST /models/pull — pulls a model from Harbor (ORAS) or HuggingFace Hub and
 records it in the manifest. Returns the local path and whether it was a cache
 hit. Per S-015 / spec Section 3.6.
+
+DELETE /models/{name} — removes a model from disk and the manifest. Rejects
+the request with 409 if any active instance references the model. Per S-017.
 """
 
 import asyncio
-from typing import List, Literal, Optional
+import os
+from pathlib import Path
+from typing import List, Literal, Optional, Union
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from solar_host import models_manager
+from solar_host.config import config_manager
+from solar_host.models.base import InstanceStatus
 from solar_host.models_manager import ModelPullError, read_manifest
 
 router = APIRouter(prefix="/models", tags=["models"])
@@ -110,7 +117,7 @@ class PullResponse(BaseModel):
         507: {"description": "Insufficient disk space"},
     },
 )
-async def pull_model(req: PullRequest) -> PullResponse:
+async def pull_model(req: PullRequest) -> Union[PullResponse, JSONResponse]:
     """Pull a model from Harbor or HuggingFace Hub.
 
     Checks the manifest cache first. On a cache hit the stored path is returned
@@ -150,3 +157,99 @@ async def pull_model(req: PullRequest) -> PullResponse:
         )
 
     return PullResponse(**result)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /models/{name}
+# ---------------------------------------------------------------------------
+
+# Statuses that mean an instance is actively using its model files.
+_ACTIVE_STATUSES = {
+    InstanceStatus.RUNNING,
+    InstanceStatus.STARTING,
+    InstanceStatus.STOPPING,
+}
+
+
+def _instance_uses_model(instance_config: object, model_dir: Path) -> bool:
+    """Return True if *instance_config* references a path under *model_dir*.
+
+    For LlamaCpp configs the ``model`` field is always a filesystem path to a
+    GGUF file.  For HuggingFace configs the ``model_id`` may be a Hub ID (e.g.
+    ``meta-llama/Llama-2-7b-hf``) or a local absolute path; only absolute
+    paths are checked against the model directory.
+    """
+    backend_type: str = getattr(instance_config, "backend_type", "")
+
+    if backend_type == "llamacpp":
+        instance_model = getattr(instance_config, "model", None)
+        if not instance_model:
+            return False
+        resolved = Path(instance_model).resolve()
+        return resolved == model_dir or resolved.is_relative_to(model_dir)
+
+    if backend_type.startswith("huggingface_"):
+        model_id: str = getattr(instance_config, "model_id", None) or ""
+        if not os.path.isabs(model_id):
+            # Hub ID (e.g. "org/model") — not a local path, skip.
+            return False
+        resolved = Path(model_id).resolve()
+        return resolved == model_dir or resolved.is_relative_to(model_dir)
+
+    return False
+
+
+def _find_using_instance(model_dir: Path) -> Optional[str]:
+    """Return the ID of the first active instance using *model_dir*, or None."""
+    for instance in config_manager.get_all_instances():
+        if instance.status not in _ACTIVE_STATUSES:
+            continue
+        if _instance_uses_model(instance.config, model_dir):
+            return instance.id
+    return None
+
+
+class DeleteResponse(BaseModel):
+    """Response body for DELETE /models/{name}."""
+
+    detail: str
+    name: str
+
+
+@router.delete(
+    "/{name}",
+    response_model=DeleteResponse,
+    summary="Delete a managed model",
+    responses={
+        200: {"description": "Model deleted successfully"},
+        404: {"description": "Model not found in manifest"},
+        409: {"description": "Model is in use by a running instance"},
+    },
+)
+async def delete_model(name: str) -> DeleteResponse:
+    """Delete a model from disk and remove it from the manifest.
+
+    The ``name`` path parameter must match the slug returned by ``GET /models``.
+    Returns 404 if the model is not in the manifest.  Returns 409 if any
+    instance with status ``running``, ``starting``, or ``stopping`` references
+    the model — stop the instance first.
+    """
+
+    def _delete() -> DeleteResponse:
+        entry = models_manager.get_manifest_entry_by_slug(name)
+        if entry is None:
+            raise HTTPException(status_code=404, detail="Model not found")
+
+        model_dir = Path(entry.path).resolve()
+        using_id = _find_using_instance(model_dir)
+        if using_id is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Model is in use by instance {using_id}. Stop the instance first.",
+            )
+
+        models_manager.delete_model_files(entry.path)
+        models_manager.remove_manifest_entry_by_slug(name)
+        return DeleteResponse(detail="Model deleted", name=name)
+
+    return await asyncio.to_thread(_delete)

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -556,9 +556,9 @@ class TestFailureCleanup:
             resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
 
         assert resp.status_code == 200
-        assert removed_before_dl.get("stale_gone") is True, (
-            "Stale directory should have been removed before download started"
-        )
+        assert (
+            removed_before_dl.get("stale_gone") is True
+        ), "Stale directory should have been removed before download started"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -1,11 +1,15 @@
-"""Tests for GET /models endpoint (solar_host/routes/models.py)."""
+"""Tests for GET /models, and DELETE /models/{name} endpoints (solar_host/routes/models.py)."""
 
 from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
 
+from solar_host.config import config_manager
 from solar_host.main import app
+from solar_host.models.base import Instance, InstanceStatus
+from solar_host.models.huggingface import HuggingFaceCausalConfig
+from solar_host.models.llamacpp import LlamaCppConfig
 from solar_host.models_manager import (
     Manifest,
     ManifestEntry,
@@ -195,3 +199,235 @@ class TestManifestOnlyNoDirectoryScan:
         assert len(data) == 1
         assert data[0]["name"] == "repo--iris-osl--v3"
         assert data[0]["size_bytes"] == 100
+
+
+# ---------------------------------------------------------------------------
+# DELETE /models/{name}
+# ---------------------------------------------------------------------------
+
+_SLUG = "repo--iris-osl--v3"
+_SOURCE_URI = "repo://iris-osl:v3"
+
+
+def _make_llamacpp_instance(
+    instance_id: str,
+    model_path: str,
+    status: InstanceStatus = InstanceStatus.RUNNING,
+) -> Instance:
+    cfg = LlamaCppConfig(model=model_path, alias="test:model")
+    return Instance(id=instance_id, config=cfg, status=status)
+
+
+def _make_hf_instance(
+    instance_id: str,
+    model_id: str,
+    status: InstanceStatus = InstanceStatus.RUNNING,
+) -> Instance:
+    cfg = HuggingFaceCausalConfig(model_id=model_id, alias="test:hf")
+    return Instance(id=instance_id, config=cfg, status=status)
+
+
+class TestDeleteModel:
+    # --- Authentication ---
+
+    def test_delete_requires_auth_missing_key(self, client: TestClient):
+        resp = client.delete(f"/models/{_SLUG}")
+        assert resp.status_code == 401
+
+    def test_delete_requires_auth_wrong_key(self, client: TestClient):
+        resp = client.delete(f"/models/{_SLUG}", headers={"X-API-Key": "wrong"})
+        assert resp.status_code == 401
+
+    # --- 404 ---
+
+    def test_delete_missing_model_returns_404(self, client: TestClient):
+        ensure_models_dir()
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    # --- 200 basic success ---
+
+    def test_delete_success_returns_200(self, client: TestClient, _isolated_env: Path):
+        ensure_models_dir()
+        add_manifest_entry(_make_entry())
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == _SLUG
+        assert "deleted" in body["detail"].lower()
+
+    def test_delete_removes_manifest_entry(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        add_manifest_entry(_make_entry())
+        client.delete(f"/models/{_SLUG}", headers=_headers())
+        # After delete the entry must be gone from the manifest.
+        resp = client.get("/models", headers=_headers())
+        assert resp.json() == []
+
+    def test_delete_removes_directory_from_disk(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        (model_dir / "model.gguf").write_bytes(b"x" * 64)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+        client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert not model_dir.exists()
+
+    def test_delete_manifest_only_no_dir_succeeds(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Manifest entry present but directory already gone — still returns 200."""
+        ensure_models_dir()
+        add_manifest_entry(_make_entry(path=str((_isolated_env / _SLUG).resolve())))
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 200
+
+    # --- 409 in-use checks ---
+
+    def test_delete_in_use_llamacpp_running_returns_409(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        gguf = model_dir / "model.gguf"
+        gguf.write_bytes(b"x" * 32)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+
+        instance = _make_llamacpp_instance("inst-1", str(gguf), InstanceStatus.RUNNING)
+        monkeypatch.setattr(config_manager, "instances", {"inst-1": instance})
+
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 409
+        assert "inst-1" in resp.json()["detail"]
+
+    def test_delete_in_use_llamacpp_starting_returns_409(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        gguf = model_dir / "model.gguf"
+        gguf.write_bytes(b"x" * 32)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+
+        instance = _make_llamacpp_instance("inst-2", str(gguf), InstanceStatus.STARTING)
+        monkeypatch.setattr(config_manager, "instances", {"inst-2": instance})
+
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 409
+
+    def test_delete_in_use_llamacpp_stopping_returns_409(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        gguf = model_dir / "model.gguf"
+        gguf.write_bytes(b"x" * 32)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+
+        instance = _make_llamacpp_instance("inst-3", str(gguf), InstanceStatus.STOPPING)
+        monkeypatch.setattr(config_manager, "instances", {"inst-3": instance})
+
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 409
+
+    def test_delete_in_use_huggingface_local_path_returns_409(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        ensure_models_dir()
+        model_dir = _isolated_env / "hf--org--mymodel"
+        model_dir.mkdir()
+        add_manifest_entry(
+            _make_entry(
+                slug="hf--org--mymodel",
+                source_uri="huggingface://org/mymodel",
+                path=str(model_dir.resolve()),
+            )
+        )
+
+        instance = _make_hf_instance(
+            "inst-hf-1", str(model_dir.resolve()), InstanceStatus.RUNNING
+        )
+        monkeypatch.setattr(config_manager, "instances", {"inst-hf-1": instance})
+
+        resp = client.delete("/models/hf--org--mymodel", headers=_headers())
+        assert resp.status_code == 409
+        assert "inst-hf-1" in resp.json()["detail"]
+
+    def test_delete_huggingface_hub_id_not_blocked(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        """An HF instance using a Hub ID (not a local path) must NOT block deletion."""
+        ensure_models_dir()
+        model_dir = _isolated_env / "hf--org--mymodel"
+        model_dir.mkdir()
+        add_manifest_entry(
+            _make_entry(
+                slug="hf--org--mymodel",
+                source_uri="huggingface://org/mymodel",
+                path=str(model_dir.resolve()),
+            )
+        )
+
+        # model_id is a Hub ID — not an absolute path
+        instance = _make_hf_instance("inst-hf-2", "org/mymodel", InstanceStatus.RUNNING)
+        monkeypatch.setattr(config_manager, "instances", {"inst-hf-2": instance})
+
+        resp = client.delete("/models/hf--org--mymodel", headers=_headers())
+        assert resp.status_code == 200
+
+    def test_delete_stopped_instance_does_not_block(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        """A STOPPED instance that references the model must not prevent deletion."""
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        gguf = model_dir / "model.gguf"
+        gguf.write_bytes(b"x" * 32)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+
+        instance = _make_llamacpp_instance(
+            "inst-stopped", str(gguf), InstanceStatus.STOPPED
+        )
+        monkeypatch.setattr(config_manager, "instances", {"inst-stopped": instance})
+
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 200
+
+    def test_delete_failed_instance_does_not_block(
+        self, client: TestClient, _isolated_env: Path, monkeypatch
+    ):
+        """A FAILED instance that references the model must not prevent deletion."""
+        ensure_models_dir()
+        model_dir = _isolated_env / _SLUG
+        model_dir.mkdir()
+        gguf = model_dir / "model.gguf"
+        gguf.write_bytes(b"x" * 32)
+        add_manifest_entry(_make_entry(path=str(model_dir.resolve())))
+
+        instance = _make_llamacpp_instance(
+            "inst-failed", str(gguf), InstanceStatus.FAILED
+        )
+        monkeypatch.setattr(config_manager, "instances", {"inst-failed": instance})
+
+        resp = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp.status_code == 200
+
+    def test_delete_second_call_returns_404(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Deleting the same model twice: first call 200, second call 404."""
+        ensure_models_dir()
+        add_manifest_entry(_make_entry())
+        resp1 = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp1.status_code == 200
+        resp2 = client.delete(f"/models/{_SLUG}", headers=_headers())
+        assert resp2.status_code == 404


### PR DESCRIPTION
## Description
Adds a DELETE /models/{name} endpoint to solar-host that allows operators to
remove managed models from disk and the manifest. The endpoint rejects deletion
with 409 Conflict if any active (running, starting, or stopping) instance
references the model, preventing runtime failures.

## Changes
- solar_host/models_manager.py: add get_manifest_entry_by_slug,
  remove_manifest_entry_by_slug (under _manifest_lock), and delete_model_files
- solar_host/routes/models.py: add DELETE /models/{name} route with 404/409/200
  responses and in-use validation for both LlamaCpp and HuggingFace backends
- tests/test_routes_models.py: 15 new tests covering all scenarios and edge cases

## Related Issues
Closes #14