### PR TITLE
fix: reliability hardening

### DIFF
--- a/solar_host/backends/huggingface.py
+++ b/solar_host/backends/huggingface.py
@@ -64,7 +64,7 @@ class HuggingFaceRunner(BackendRunner):
         ):
             model_type = "embedding"
         else:
-            model_type = "causal"  # fallback
+            raise RuntimeError(f"Unknown HuggingFace backend_type: {backend_type!r}")
 
         cmd = [
             sys.executable,
@@ -202,13 +202,15 @@ class HuggingFaceRunner(BackendRunner):
         m = self._re_request_complete.search(line)
         if m:
             context["busy"] = False
-            tokens = int(m.group(2))
-            time_ms = float(m.group(3))
+            try:
+                tokens = int(m.group(2))
+                time_ms = float(m.group(3))
+            except (ValueError, TypeError):
+                tokens = 0
+                time_ms = 0.0
 
-            # Calculate TPS
             tps = (tokens / time_ms * 1000) if time_ms > 0 else None
 
-            # Store generation metrics
             if context.get("current_request"):
                 metrics = GenerationMetrics(
                     instance_id=instance_id,

--- a/solar_host/backends/llamacpp.py
+++ b/solar_host/backends/llamacpp.py
@@ -34,9 +34,6 @@ class LlamaCppRunner(BackendRunner):
         self._re_print_timing = re.compile(
             r"slot\s+print_timing:\s+id\s+(\d+)\s*\|\s*task\s+(-?\d+)\s*\|"
         )
-        self._re_prompt_eval_line = re.compile(
-            r"prompt eval time\s*=\s*([0-9.]+)\s*ms\s*/\s*(\d+)\s*tokens\s*\(\s*([0-9.]+)\s*ms per token,\s*([0-9.]+)\s*tokens per second\)"
-        )
         self._re_decode_eval_line = re.compile(
             r"\s*eval time\s*=\s*([0-9.]+)\s*ms\s*/\s*(\d+)\s*tokens\s*\(\s*([0-9.]+)\s*ms per token,\s*([0-9.]+)\s*tokens per second\)"
         )

--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 from pydantic_settings import BaseSettings
 
-logger = logging.getLogger(__name__)
-
 from solar_host.models.base import Instance, InstanceStatus
 from solar_host.models.llamacpp import LlamaCppConfig
 from solar_host.models.huggingface import (
@@ -17,6 +15,8 @@ from solar_host.models.huggingface import (
     HuggingFaceClassificationConfig,
     HuggingFaceEmbeddingConfig,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):

--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -1,9 +1,14 @@
 """Configuration management for solar-host."""
 
 import json
+import logging
+import os
+import threading
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 from pydantic_settings import BaseSettings
+
+logger = logging.getLogger(__name__)
 
 from solar_host.models.base import Instance, InstanceStatus
 from solar_host.models.llamacpp import LlamaCppConfig
@@ -96,14 +101,19 @@ def parse_instance_config(config_data: Dict[str, Any]) -> Any:
     elif backend_type == "huggingface_embedding":
         return HuggingFaceEmbeddingConfig(**config_data)
     else:
-        # Fallback to llamacpp
-        return LlamaCppConfig(**config_data)
+        raise ValueError(f"Unknown backend_type: {backend_type!r}")
 
 
 class ConfigManager:
-    """Manages instance configurations and persistence."""
+    """Manages instance configurations and persistence.
+
+    All public methods are protected by a threading lock so the instance
+    dict and on-disk config.json stay consistent across the asyncio event
+    loop thread and background log-reader threads.
+    """
 
     def __init__(self, config_file: Optional[str] = None):
+        self._lock = threading.Lock()
         self.config_file = Path(config_file or settings.config_file)
         self.instances: Dict[str, Instance] = {}
         self.roles: List[str] = ["inference"]
@@ -111,41 +121,40 @@ class ConfigManager:
 
     def load(self):
         """Load configuration from disk with backward compatibility."""
+        with self._lock:
+            self._load_unlocked()
+
+    def _load_unlocked(self):
         if self.config_file.exists():
             try:
                 with open(self.config_file, "r") as f:
                     data = json.load(f)
                     self.roles = data.get("roles", ["inference"])
+                    self.instances = {}
                     for instance_data in data.get("instances", []):
                         try:
-                            # Migrate config if needed
                             if "config" in instance_data:
                                 instance_data["config"] = migrate_config_data(
                                     instance_data["config"]
                                 )
-
-                            # Parse config into appropriate type
                             config = parse_instance_config(
                                 instance_data.get("config", {})
                             )
-
-                            # Create instance with parsed config
                             instance_data_copy = instance_data.copy()
                             instance_data_copy["config"] = config
-
                             instance = Instance(**instance_data_copy)
                             self.instances[instance.id] = instance
                         except Exception as e:
-                            print(f"Error loading instance: {e}")
+                            logger.warning("Skipping instance during load: %s", e)
                             continue
             except Exception as e:
-                print(f"Error loading config: {e}")
+                logger.error("Error loading config: %s", e)
                 self.instances = {}
         else:
             self.instances = {}
 
-    def save(self):
-        """Save configuration to disk."""
+    def _save_unlocked(self):
+        """Write config to disk atomically (tmp + os.replace)."""
         try:
             data = {
                 "roles": self.roles,
@@ -155,56 +164,69 @@ class ConfigManager:
                 ],
             }
             self.config_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.config_file, "w") as f:
+            tmp = self.config_file.with_suffix(".json.tmp")
+            with open(tmp, "w") as f:
                 json.dump(data, f, indent=2, default=str)
+            os.replace(tmp, self.config_file)
         except Exception as e:
-            print(f"Error saving config: {e}")
+            logger.error("Error saving config: %s", e)
+
+    def save(self):
+        """Save configuration to disk (thread-safe)."""
+        with self._lock:
+            self._save_unlocked()
 
     def add_instance(self, instance: Instance):
         """Add a new instance."""
-        self.instances[instance.id] = instance
-        self.save()
+        with self._lock:
+            self.instances[instance.id] = instance
+            self._save_unlocked()
 
     def update_instance(self, instance_id: str, instance: Instance):
         """Update an existing instance."""
-        if instance_id in self.instances:
-            self.instances[instance_id] = instance
-            self.save()
+        with self._lock:
+            if instance_id in self.instances:
+                self.instances[instance_id] = instance
+                self._save_unlocked()
 
     def update_instance_runtime(self, instance_id: str, **kwargs):
         """Update ephemeral runtime fields for an instance (no disk write)."""
-        instance = self.instances.get(instance_id)
-        if not instance:
-            return
-        # Only mutate known runtime fields
-        if "busy" in kwargs:
-            instance.busy = bool(kwargs["busy"])
-        if "prefill_progress" in kwargs:
-            instance.prefill_progress = kwargs["prefill_progress"]
-        if "active_slots" in kwargs:
-            instance.active_slots = int(kwargs["active_slots"])
+        with self._lock:
+            instance = self.instances.get(instance_id)
+            if not instance:
+                return
+            if "busy" in kwargs:
+                instance.busy = bool(kwargs["busy"])
+            if "prefill_progress" in kwargs:
+                instance.prefill_progress = kwargs["prefill_progress"]
+            if "active_slots" in kwargs:
+                instance.active_slots = int(kwargs["active_slots"])
 
     def remove_instance(self, instance_id: str):
         """Remove an instance."""
-        if instance_id in self.instances:
-            del self.instances[instance_id]
-            self.save()
+        with self._lock:
+            if instance_id in self.instances:
+                del self.instances[instance_id]
+                self._save_unlocked()
 
     def get_instance(self, instance_id: str) -> Optional[Instance]:
         """Get an instance by ID."""
-        return self.instances.get(instance_id)
+        with self._lock:
+            return self.instances.get(instance_id)
 
     def get_all_instances(self) -> List[Instance]:
         """Get all instances."""
-        return list(self.instances.values())
+        with self._lock:
+            return list(self.instances.values())
 
     def get_running_instances(self) -> List[Instance]:
         """Get all running instances."""
-        return [
-            instance
-            for instance in self.instances.values()
-            if instance.status == InstanceStatus.RUNNING
-        ]
+        with self._lock:
+            return [
+                instance
+                for instance in self.instances.values()
+                if instance.status == InstanceStatus.RUNNING
+            ]
 
 
 # Global config manager instance

--- a/solar_host/main.py
+++ b/solar_host/main.py
@@ -216,9 +216,7 @@ async def get_memory():
             memory_type=str(memory_info["memory_type"]),
         )
     except (KeyError, TypeError, ValueError) as e:
-        raise HTTPException(
-            status_code=503, detail=f"Memory data malformed: {e}"
-        )
+        raise HTTPException(status_code=503, detail=f"Memory data malformed: {e}")
 
 
 @app.post("/reconnect")
@@ -233,7 +231,9 @@ async def reconnect_to_control():
 
     client = get_client()
     if not client:
-        raise HTTPException(status_code=503, detail="No solar-control client configured")
+        raise HTTPException(
+            status_code=503, detail="No solar-control client configured"
+        )
     if client.is_connected:
         return {"status": "already_connected"}
     triggered = await client.reconnect()

--- a/solar_host/main.py
+++ b/solar_host/main.py
@@ -1,15 +1,20 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from contextlib import asynccontextmanager
-import asyncio
 
 from solar_host import __version__
 from solar_host.config import settings
+from solar_host.models.base import BackendType
 from solar_host.models_manager import ensure_models_dir, get_models_dir
 from solar_host.process_manager import process_manager
 from solar_host.routes import instances, models, websockets
 from solar_host.ws_client import init_clients, get_clients, get_client, broadcast_health
+
+logger = logging.getLogger(__name__)
 
 
 async def health_report_loop():
@@ -23,51 +28,46 @@ async def health_report_loop():
         except asyncio.CancelledError:
             break
         except Exception as e:
-            print(f"Health report error: {e}")
+            logger.warning("Health report error: %s", e)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifecycle manager for the application"""
-    # Startup: Auto-restart instances that were running
-    print("Starting Solar Host...")
-    print(f"API Key configured: {settings.api_key[:4]}...")
+    key_hint = settings.api_key[:4] if len(settings.api_key) >= 4 else "***"
+    logger.info("Starting Solar Host...")
+    logger.info("API Key configured: %s...", key_hint)
     if settings.insecure:
-        print(
-            "WARNING: INSECURE mode enabled - TLS certificate verification is disabled"
+        logger.warning(
+            "INSECURE mode enabled - TLS certificate verification is disabled"
         )
 
-    # Ensure the managed models directory exists
     ensure_models_dir()
-    print(f"Models directory: {get_models_dir()}")
+    logger.info("Models directory: %s", get_models_dir())
 
-    # Initialize and start solar-control WebSocket clients
     clients = init_clients(settings)
     health_task = None
     watchdog_task = None
     if clients:
         for client in clients:
             await client.start()
-        # Start the batched emission flush loop
         loop = asyncio.get_running_loop()
         process_manager.ensure_flush_loop(loop)
         health_task = asyncio.create_task(health_report_loop())
-        print(
-            f"Solar Control WebSocket client(s) started ({len(clients)} connection(s))"
+        logger.info(
+            "Solar Control WebSocket client(s) started (%d connection(s))", len(clients)
         )
     else:
-        print("Solar Control WebSocket client not configured (standalone mode)")
+        logger.info("Solar Control WebSocket client not configured (standalone mode)")
 
-    # Periodically reconcile child process state (detect exits without log EOF)
     watchdog_task = asyncio.create_task(process_manager.watchdog_loop())
 
     await process_manager.auto_restart_running_instances()
-    print("Solar Host started successfully")
+    logger.info("Solar Host started successfully")
 
     yield
 
-    # Shutdown: Clean up
-    print("Shutting down Solar Host...")
+    logger.info("Shutting down Solar Host...")
 
     if health_task:
         health_task.cancel()
@@ -95,11 +95,10 @@ app = FastAPI(
     swagger_ui_parameters={"persistAuthorization": True},
 )
 
-# CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -125,7 +124,6 @@ async def verify_api_key(request: Request, call_next):
             content={"detail": "Invalid or missing API key"},
             headers={
                 "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Credentials": "true",
                 "Access-Control-Allow-Methods": "*",
                 "Access-Control-Allow-Headers": "*",
             },
@@ -195,11 +193,7 @@ async def root():
         "service": "solar-host",
         "version": __version__,
         "description": "Process manager for model inference backends (llama.cpp, HuggingFace)",
-        "supported_backends": [
-            "llamacpp",
-            "huggingface_causal",
-            "huggingface_classification",
-        ],
+        "supported_backends": [bt.value for bt in BackendType],
     }
 
 
@@ -213,27 +207,18 @@ async def get_memory():
     memory_info = await asyncio.to_thread(get_memory_info)
     if not memory_info:
         raise HTTPException(status_code=503, detail="Memory information not available")
-    # Coerce types explicitly to satisfy typing
     try:
-        used_gb = float(memory_info.get("used_gb"))  # type: ignore[arg-type]
-        total_gb = float(memory_info.get("total_gb"))  # type: ignore[arg-type]
-        available_gb = float(memory_info.get("available_gb"))  # type: ignore[arg-type]
-        percent = float(memory_info.get("percent"))  # type: ignore[arg-type]
-        memory_type = str(memory_info.get("memory_type"))
-    except Exception:
-        used_gb = 0.0
-        total_gb = 0.0
-        available_gb = 0.0
-        percent = 0.0
-        memory_type = "RAM"
-
-    return MemoryInfo(
-        used_gb=used_gb,
-        total_gb=total_gb,
-        available_gb=available_gb,
-        percent=percent,
-        memory_type=memory_type,
-    )
+        return MemoryInfo(
+            used_gb=float(memory_info["used_gb"]),
+            total_gb=float(memory_info["total_gb"]),
+            available_gb=float(memory_info["available_gb"]),
+            percent=float(memory_info["percent"]),
+            memory_type=str(memory_info["memory_type"]),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=503, detail=f"Memory data malformed: {e}"
+        )
 
 
 @app.post("/reconnect")
@@ -244,13 +229,17 @@ async def reconnect_to_control():
     session has disconnected, prompting an immediate reconnection attempt
     instead of waiting for the next backoff cycle.
     """
+    from fastapi import HTTPException
+
     client = get_client()
     if not client:
-        return {"status": "no_client"}
+        raise HTTPException(status_code=503, detail="No solar-control client configured")
     if client.is_connected:
         return {"status": "already_connected"}
     triggered = await client.reconnect()
-    return {"status": "reconnecting" if triggered else "failed"}
+    if triggered:
+        return {"status": "reconnecting"}
+    raise HTTPException(status_code=503, detail="Failed to trigger reconnection")
 
 
 def run():

--- a/solar_host/memory_monitor.py
+++ b/solar_host/memory_monitor.py
@@ -41,10 +41,12 @@ def get_memory_info() -> Optional[Dict[str, Union[float, str]]]:
 
     system = platform.system()
 
-    if system == "Darwin":  # macOS
+    if system == "Darwin":
         result = _get_mac_memory()
-    else:  # Windows or Linux
+    else:
         result = _get_nvidia_memory()
+        if result is None:
+            result = _get_system_memory()
 
     # Update cache
     if result:
@@ -90,27 +92,24 @@ def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:
         import pynvml  # type: ignore
 
         pynvml.nvmlInit()
-        device_count = pynvml.nvmlDeviceGetCount()
+        try:
+            device_count = pynvml.nvmlDeviceGetCount()
+            if device_count == 0:
+                return None
 
-        if device_count == 0:
-            return None
+            total_used = 0
+            total_capacity = 0
+            for i in range(device_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                total_used += info.used
+                total_capacity += info.total
+        finally:
+            pynvml.nvmlShutdown()
 
-        total_used = 0
-        total_capacity = 0
-
-        for i in range(device_count):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            total_used += info.used
-            total_capacity += info.total
-
-        pynvml.nvmlShutdown()
-
-        # Convert bytes to GB
         used_gb = total_used / (1024**3)
         total_gb = total_capacity / (1024**3)
         percent = (total_used / total_capacity * 100) if total_capacity > 0 else 0
-
         available_gb = total_gb - used_gb
 
         return {
@@ -121,7 +120,24 @@ def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:
             "memory_type": "VRAM",
         }
     except Exception:
-        # No NVIDIA GPU or driver not available
+        return None
+
+
+def _get_system_memory() -> Optional[Dict[str, Union[float, str]]]:
+    """Get system RAM info via psutil (fallback for Linux without NVIDIA)."""
+    try:
+        mem = psutil.virtual_memory()
+        used_gb = mem.used / (1024**3)
+        total_gb = mem.total / (1024**3)
+        available_gb = total_gb - used_gb
+        return {
+            "used_gb": round(used_gb, 2),
+            "total_gb": round(total_gb, 2),
+            "available_gb": round(available_gb, 2),
+            "percent": round(mem.percent, 2),
+            "memory_type": "RAM",
+        }
+    except Exception:
         return None
 
 

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -334,7 +334,11 @@ def pull_model(
         cached_entry = get_manifest_entry(source_uri)
         if cached_entry is not None:
             if Path(cached_entry.path).exists():
-                return {"path": cached_entry.path, "cached": True, "source_uri": source_uri}
+                return {
+                    "path": cached_entry.path,
+                    "cached": True,
+                    "source_uri": source_uri,
+                }
             logger.warning(
                 "Manifest entry for %s points to missing path %s, re-pulling",
                 source_uri,

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -330,9 +330,18 @@ def pull_model(
     uri_lock = _get_uri_lock(source_uri)
     with uri_lock:
         # 2. Cache check — manifest is the single source of truth.
+        #    Verify the files still exist on disk; remove stale entries.
         cached_entry = get_manifest_entry(source_uri)
         if cached_entry is not None:
-            return {"path": cached_entry.path, "cached": True, "source_uri": source_uri}
+            if Path(cached_entry.path).exists():
+                return {"path": cached_entry.path, "cached": True, "source_uri": source_uri}
+            logger.warning(
+                "Manifest entry for %s points to missing path %s, re-pulling",
+                source_uri,
+                cached_entry.path,
+            )
+            with _manifest_lock:
+                remove_manifest_entry(source_uri)
 
         # 3. Derive slug and target directory.
         try:

--- a/solar_host/process_manager.py
+++ b/solar_host/process_manager.py
@@ -410,7 +410,9 @@ class ProcessManager:
             await asyncio.sleep(1)
         return False
 
-    async def _try_start_instance(self, instance_id: str, attempt: int) -> Optional[bool]:
+    async def _try_start_instance(
+        self, instance_id: str, attempt: int
+    ) -> Optional[bool]:
         """Single start attempt. Returns True/False for final result, None to retry."""
         instance = config_manager.get_instance(instance_id)
         if not instance:
@@ -616,7 +618,10 @@ class ProcessManager:
                 InstanceStatus.RUNNING,
                 InstanceStatus.STARTING,
             ):
-                logger.error("Cannot restart %s: stop failed and instance is still active", instance_id)
+                logger.error(
+                    "Cannot restart %s: stop failed and instance is still active",
+                    instance_id,
+                )
                 return False
         await asyncio.sleep(1)
         return await self.start_instance(instance_id)
@@ -688,7 +693,9 @@ class ProcessManager:
                         )
                         break
         except Exception:
-            logger.debug("Failed to push instances update to solar-control", exc_info=True)
+            logger.debug(
+                "Failed to push instances update to solar-control", exc_info=True
+            )
 
     def delete_instance(self, instance_id: str) -> bool:
         """Delete an instance and notify solar-control."""
@@ -699,7 +706,9 @@ class ProcessManager:
         # Defensively terminate any lingering process
         process = self.processes.pop(instance_id, None)
         if process and process.poll() is None:
-            logger.warning("Terminating orphan process for deleted instance %s", instance_id)
+            logger.warning(
+                "Terminating orphan process for deleted instance %s", instance_id
+            )
             try:
                 process.terminate()
                 process.wait(timeout=5)
@@ -728,7 +737,9 @@ class ProcessManager:
         for instance in config_manager.get_all_instances():
             if instance.status in (InstanceStatus.RUNNING, InstanceStatus.STARTING):
                 logger.info(
-                    "Auto-restarting instance: %s (%s)", instance.id, instance.config.alias
+                    "Auto-restarting instance: %s (%s)",
+                    instance.id,
+                    instance.config.alias,
                 )
                 self._kill_stale_pid(instance.pid)
                 instance.status = InstanceStatus.STOPPED
@@ -753,6 +764,7 @@ class ProcessManager:
             return
         try:
             import signal
+
             os.kill(pid, signal.SIGTERM)
             logger.info("Sent SIGTERM to stale PID %d", pid)
         except ProcessLookupError:

--- a/solar_host/process_manager.py
+++ b/solar_host/process_manager.py
@@ -1,5 +1,6 @@
 """Process manager for solar-host with multi-backend support."""
 
+import logging
 import subprocess
 import socket
 import time
@@ -34,8 +35,11 @@ from solar_host.ws_client import (
     broadcast_instances_update,
 )
 
+logger = logging.getLogger(__name__)
+
 FLUSH_INTERVAL_S = 0.1
 WATCHDOG_INTERVAL_S = 15.0
+MAX_QUEUE_SIZE = 10_000
 _HAS_STDBUF = shutil.which("stdbuf") is not None
 
 
@@ -80,9 +84,10 @@ class ProcessManager:
         # Per-instance runner reference
         self.instance_runners: Dict[str, BackendRunner] = {}
 
-        # Batched emission queues (thread-safe, drained by _flush_loop)
-        self._log_queue: queue.SimpleQueue = queue.SimpleQueue()
-        self._state_queue: queue.SimpleQueue = queue.SimpleQueue()
+        # Batched emission queues (thread-safe, drained by _flush_loop).
+        # Bounded to prevent OOM if the flush loop or WS broadcast stalls.
+        self._log_queue: queue.Queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
+        self._state_queue: queue.Queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
         self._flush_task: Optional[asyncio.Task] = None
         self._child_exit_lock = threading.Lock()
 
@@ -228,7 +233,7 @@ class ProcessManager:
                         # Parsing errors should not break logging
                         pass
         except Exception as e:
-            print(f"Error reading logs for {instance_id}: {e}")
+            logger.warning("Error reading logs for %s: %s", instance_id, e)
         finally:
             # stdout closed or reader error: child likely exited — reconcile state
             self._handle_child_exit(instance_id, process)
@@ -253,7 +258,8 @@ class ProcessManager:
                 await self._flush_pending()
                 break
             except Exception:
-                pass
+                logger.exception("Error in flush loop")
+                await asyncio.sleep(1)
 
     async def _flush_pending(self):
         """Drain both queues and emit batched events."""
@@ -291,18 +297,25 @@ class ProcessManager:
             except asyncio.CancelledError:
                 break
             except Exception:
-                pass
+                logger.exception("Error in watchdog loop")
+                await asyncio.sleep(1)
 
     def _push_log_event(self, instance_id: str, seq: int, line: str, timestamp: str):
-        """Queue a log event for batched emission (thread-safe, non-blocking)."""
-        self._log_queue.put(
-            {
-                "instance_id": instance_id,
-                "seq": seq,
-                "line": line,
-                "timestamp": timestamp,
-            }
-        )
+        """Queue a log event for batched emission (thread-safe, non-blocking).
+
+        Silently discards events when the queue is full to prevent OOM.
+        """
+        try:
+            self._log_queue.put_nowait(
+                {
+                    "instance_id": instance_id,
+                    "seq": seq,
+                    "line": line,
+                    "timestamp": timestamp,
+                }
+            )
+        except queue.Full:
+            pass
 
     def _emit_state_event(self, instance_id: str, update):
         """Emit a state event from a RuntimeStateUpdate."""
@@ -350,27 +363,33 @@ class ProcessManager:
         self._push_state_event(instance_id, state)
 
     def _push_state_event(self, instance_id: str, state: InstanceRuntimeState):
-        """Queue a state event for batched emission (thread-safe, non-blocking)."""
-        self._state_queue.put(
-            {
-                "instance_id": instance_id,
-                "timestamp": state.timestamp,
-                "data": {
-                    "busy": state.busy,
-                    "phase": state.phase.value if state.phase else None,
-                    "prefill_progress": state.prefill_progress,
-                    "active_slots": state.active_slots,
-                    "slot_id": state.slot_id,
-                    "task_id": state.task_id,
-                    "prefill_prompt_tokens": state.prefill_prompt_tokens,
-                    "generated_tokens": state.generated_tokens,
-                    "decode_tps": state.decode_tps,
-                    "decode_ms_per_token": state.decode_ms_per_token,
-                    "checkpoint_index": state.checkpoint_index,
-                    "checkpoint_total": state.checkpoint_total,
-                },
-            }
-        )
+        """Queue a state event for batched emission (thread-safe, non-blocking).
+
+        Silently discards events when the queue is full to prevent OOM.
+        """
+        try:
+            self._state_queue.put_nowait(
+                {
+                    "instance_id": instance_id,
+                    "timestamp": state.timestamp,
+                    "data": {
+                        "busy": state.busy,
+                        "phase": state.phase.value if state.phase else None,
+                        "prefill_progress": state.prefill_progress,
+                        "active_slots": state.active_slots,
+                        "slot_id": state.slot_id,
+                        "task_id": state.task_id,
+                        "prefill_prompt_tokens": state.prefill_prompt_tokens,
+                        "generated_tokens": state.generated_tokens,
+                        "decode_tps": state.decode_tps,
+                        "decode_ms_per_token": state.decode_ms_per_token,
+                        "checkpoint_index": state.checkpoint_index,
+                        "checkpoint_total": state.checkpoint_total,
+                    },
+                }
+            )
+        except queue.Full:
+            pass
 
     def get_last_generation(self, instance_id: str) -> Optional[GenerationMetrics]:
         """Get the last generation metrics for an instance."""
@@ -382,7 +401,17 @@ class ProcessManager:
         return None
 
     async def start_instance(self, instance_id: str) -> bool:
-        """Start a model server instance."""
+        """Start a model server instance with iterative retry."""
+        for attempt in range(1 + settings.max_retries):
+            result = await self._try_start_instance(instance_id, attempt)
+            if result is not None:
+                return result
+            # result is None means "retry"
+            await asyncio.sleep(1)
+        return False
+
+    async def _try_start_instance(self, instance_id: str, attempt: int) -> Optional[bool]:
+        """Single start attempt. Returns True/False for final result, None to retry."""
         instance = config_manager.get_instance(instance_id)
         if not instance:
             return False
@@ -392,7 +421,7 @@ class ProcessManager:
             proc = self.processes.get(instance_id)
             if proc and proc.poll() is None:
                 return True
-            # Stale RUNNING: process missing or dead — reset and continue start
+            # Stale RUNNING: process missing or dead -- reset and continue start
             if proc is not None:
                 self.processes.pop(instance_id, None)
             self._purge_instance_resources(instance_id, call_runner_on_stop=True)
@@ -402,21 +431,15 @@ class ProcessManager:
             instance.error_message = None
             config_manager.update_instance(instance_id, instance)
 
-        # Always find an available port on start
         instance.port = self._get_available_port()
 
-        # Get the appropriate runner for this backend type
         runner = get_runner_for_config(instance.config)
         self.instance_runners[instance_id] = runner
-
-        # Initialize parsing context
         self.instance_contexts[instance_id] = runner.initialize_context()
 
-        # Update status
         instance.status = InstanceStatus.STARTING
         instance.error_message = None
 
-        # Set supported endpoints (use model_type for llamacpp differentiation)
         if hasattr(runner, "get_supported_endpoints_for_model_type"):
             model_type = getattr(instance.config, "model_type", "llm")
             instance.supported_endpoints = (
@@ -433,21 +456,15 @@ class ProcessManager:
         config_manager.update_instance(instance_id, instance)
 
         try:
-            # Build command using runner
             cmd = runner.build_command(instance)
 
-            # Create log file
             alias_safe = instance.config.alias.replace(":", "-").replace("/", "-")
             log_file = self.log_dir / f"{alias_safe}_{int(time.time())}.log"
 
-            # Force line-buffered stdout so lines arrive in generation
-            # order (stdout is block-buffered when piped, causing lines
-            # to arrive after subsequent stderr output).
             run_env = os.environ.copy()
             run_env["PYTHONUNBUFFERED"] = "1"
             run_cmd = ["stdbuf", "-oL"] + cmd if _HAS_STDBUF else cmd
 
-            # Start process
             process = subprocess.Popen(
                 run_cmd,
                 stdout=subprocess.PIPE,
@@ -458,7 +475,6 @@ class ProcessManager:
 
             self.processes[instance_id] = process
 
-            # Start log reading thread
             log_thread = threading.Thread(
                 target=self._read_logs,
                 args=(instance_id, process, log_file, runner),
@@ -469,8 +485,6 @@ class ProcessManager:
 
             await asyncio.sleep(2)
 
-            # Re-read instance state - another coroutine (e.g. stop) may have
-            # changed the status while we slept.
             instance = config_manager.get_instance(instance_id)
             if not instance or instance.status not in (
                 InstanceStatus.STARTING,
@@ -487,47 +501,39 @@ class ProcessManager:
                 instance.retry_count = 0
                 config_manager.update_instance(instance_id, instance)
 
-                # Initialize ephemeral runtime state
                 self.state_buffers[instance_id] = deque(maxlen=settings.log_buffer_size)
                 self.state_sequences[instance_id] = 0
                 config_manager.update_instance_runtime(
                     instance_id, busy=False, prefill_progress=None, active_slots=0
                 )
 
-                # Notify runner that process started
                 runner.on_process_started(
                     instance_id, self.instance_contexts[instance_id]
                 )
 
-                # Notify solar-control of instance update
                 self._push_instances_update()
 
                 return True
             else:
-                # Process failed
                 instance.status = InstanceStatus.FAILED
                 instance.error_message = "Process exited immediately"
-                instance.retry_count += 1
+                instance.retry_count = attempt + 1
                 config_manager.update_instance(instance_id, instance)
 
-                # Retry if under limit
                 if instance.retry_count < settings.max_retries:
-                    await asyncio.sleep(1)
-                    return await self.start_instance(instance_id)
-
+                    return None  # signal retry
                 return False
 
         except Exception as e:
-            instance.status = InstanceStatus.FAILED
-            instance.error_message = str(e)
-            instance.retry_count += 1
-            config_manager.update_instance(instance_id, instance)
+            instance = config_manager.get_instance(instance_id)
+            if instance:
+                instance.status = InstanceStatus.FAILED
+                instance.error_message = str(e)
+                instance.retry_count = attempt + 1
+                config_manager.update_instance(instance_id, instance)
 
-            # Retry if under limit
-            if instance.retry_count < settings.max_retries:
-                await asyncio.sleep(1)
-                return await self.start_instance(instance_id)
-
+                if instance.retry_count < settings.max_retries:
+                    return None  # signal retry
             return False
 
     async def stop_instance(self, instance_id: str) -> bool:
@@ -565,6 +571,11 @@ class ProcessManager:
 
                 self.processes.pop(instance_id, None)
 
+            # Wait for log thread to finish before purging resources
+            log_thread = self.log_threads.get(instance_id)
+            if log_thread and log_thread.is_alive():
+                log_thread.join(timeout=5)
+
             self._purge_instance_resources(instance_id, call_runner_on_stop=True)
 
             instance.status = InstanceStatus.STOPPED
@@ -572,10 +583,8 @@ class ProcessManager:
             instance.started_at = None
             config_manager.update_instance(instance_id, instance)
 
-            # Clean up old log file for stopped instances
             await self._cleanup_old_logs(instance.config.alias)
 
-            # Notify solar-control of instance update
             self._push_instances_update()
 
             return True
@@ -596,11 +605,19 @@ class ProcessManager:
                 if log_file.stat().st_mtime < time.time() - 300:  # 5 minutes old
                     log_file.unlink()
         except Exception as e:
-            print(f"Error cleaning up logs: {e}")
+            logger.warning("Error cleaning up logs: %s", e)
 
     async def restart_instance(self, instance_id: str) -> bool:
         """Restart a model server instance."""
-        await self.stop_instance(instance_id)
+        stopped = await self.stop_instance(instance_id)
+        if not stopped:
+            instance = config_manager.get_instance(instance_id)
+            if instance and instance.status in (
+                InstanceStatus.RUNNING,
+                InstanceStatus.STARTING,
+            ):
+                logger.error("Cannot restart %s: stop failed and instance is still active", instance_id)
+                return False
         await asyncio.sleep(1)
         return await self.start_instance(instance_id)
 
@@ -664,16 +681,14 @@ class ProcessManager:
             clients = get_clients()
             for client in clients:
                 if client.is_connected:
-                    # Get the main event loop (stored when the app starts)
                     loop = getattr(client, "_main_loop", None)
                     if loop and loop.is_running():
                         asyncio.run_coroutine_threadsafe(
                             broadcast_instances_update(), loop
                         )
-                        break  # Only need to schedule once, broadcast handles all
+                        break
         except Exception:
-            # Never let WS errors break instance operations
-            pass
+            logger.debug("Failed to push instances update to solar-control", exc_info=True)
 
     def delete_instance(self, instance_id: str) -> bool:
         """Delete an instance and notify solar-control."""
@@ -681,18 +696,26 @@ class ProcessManager:
         if not instance:
             return False
 
+        # Defensively terminate any lingering process
+        process = self.processes.pop(instance_id, None)
+        if process and process.poll() is None:
+            logger.warning("Terminating orphan process for deleted instance %s", instance_id)
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except Exception:
+                process.kill()
+                process.wait()
+
         config_manager.remove_instance(instance_id)
 
-        # Cleanup any lingering buffers
-        self.log_buffers.pop(instance_id, None)
-        self.log_sequences.pop(instance_id, None)
-        self.log_threads.pop(instance_id, None)
-        self.state_buffers.pop(instance_id, None)
-        self.state_sequences.pop(instance_id, None)
-        self.instance_runners.pop(instance_id, None)
-        self.instance_contexts.pop(instance_id, None)
+        # Wait for log thread to finish before removing buffers
+        log_thread = self.log_threads.pop(instance_id, None)
+        if log_thread and log_thread.is_alive():
+            log_thread.join(timeout=3)
 
-        # Notify solar-control of instance update
+        self._purge_instance_resources(instance_id, call_runner_on_stop=False)
+
         self._push_instances_update()
 
         return True
@@ -704,20 +727,38 @@ class ProcessManager:
         """
         for instance in config_manager.get_all_instances():
             if instance.status in (InstanceStatus.RUNNING, InstanceStatus.STARTING):
-                print(
-                    f"Auto-restarting instance: {instance.id} ({instance.config.alias})"
+                logger.info(
+                    "Auto-restarting instance: %s (%s)", instance.id, instance.config.alias
                 )
+                self._kill_stale_pid(instance.pid)
                 instance.status = InstanceStatus.STOPPED
                 instance.pid = None
                 config_manager.update_instance(instance.id, instance)
                 await self.start_instance(instance.id)
             elif instance.status == InstanceStatus.STOPPING:
-                print(
-                    f"Resolving interrupted stop for instance: {instance.id} ({instance.config.alias})"
+                logger.info(
+                    "Resolving interrupted stop for instance: %s (%s)",
+                    instance.id,
+                    instance.config.alias,
                 )
+                self._kill_stale_pid(instance.pid)
                 instance.status = InstanceStatus.STOPPED
                 instance.pid = None
                 config_manager.update_instance(instance.id, instance)
+
+    @staticmethod
+    def _kill_stale_pid(pid: Optional[int]) -> None:
+        """Best-effort kill of a stale PID left from a previous run."""
+        if pid is None:
+            return
+        try:
+            import signal
+            os.kill(pid, signal.SIGTERM)
+            logger.info("Sent SIGTERM to stale PID %d", pid)
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            logger.debug("Could not kill stale PID %d: %s", pid, e)
 
 
 # Global process manager instance

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -216,39 +216,36 @@ async def get_last_generation(
     if not metrics:
         raise HTTPException(status_code=404, detail="No generation metrics available")
 
-    # Apply filters
-    try:
-        from datetime import datetime, timezone
+    from datetime import datetime, timezone
 
-        def parse_iso(ts: str | None):
-            if not ts:
-                return None
-            try:
-                return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(
-                    timezone.utc
-                )
-            except Exception:
-                return None
+    def parse_iso(ts: str | None):
+        if not ts:
+            return None
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        )
 
-        finished_dt = parse_iso(metrics.finished_at)
-        if after:
+    finished_dt = parse_iso(metrics.finished_at)
+
+    if after:
+        try:
             after_dt = parse_iso(after)
-            if after_dt and finished_dt and finished_dt < after_dt:
-                raise HTTPException(
-                    status_code=404,
-                    detail="No generation metrics after the specified timestamp",
-                )
-        if within_s is not None and within_s >= 0:
-            now_dt = datetime.now(timezone.utc)
-            if finished_dt and (now_dt - finished_dt).total_seconds() > float(within_s):
-                raise HTTPException(
-                    status_code=404,
-                    detail="No recent generation metrics within the specified window",
-                )
-    except HTTPException:
-        raise
-    except Exception:
-        # On any parsing error, return the metrics without filtering
-        pass
+        except (ValueError, TypeError):
+            raise HTTPException(
+                status_code=400, detail=f"Invalid 'after' timestamp: {after!r}"
+            )
+        if after_dt and finished_dt and finished_dt < after_dt:
+            raise HTTPException(
+                status_code=404,
+                detail="No generation metrics after the specified timestamp",
+            )
+
+    if within_s is not None and within_s >= 0:
+        now_dt = datetime.now(timezone.utc)
+        if finished_dt and (now_dt - finished_dt).total_seconds() > float(within_s):
+            raise HTTPException(
+                status_code=404,
+                detail="No recent generation metrics within the specified window",
+            )
 
     return metrics

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -8,9 +8,12 @@ handling:
 """
 
 import asyncio
+import logging
 import ssl
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
+
+logger = logging.getLogger(__name__)
 
 try:
     import socketio
@@ -85,11 +88,11 @@ class SolarControlClient:
     async def start(self):
         """Start the Socket.IO client and connect to solar-control."""
         if not self.control_url:
-            print("SolarControlClient: No control URL configured, skipping connection")
+            logger.info("SolarControlClient: No control URL configured, skipping connection")
             return
 
         if not HAS_SOCKETIO:
-            print(
+            logger.warning(
                 "SolarControlClient: python-socketio not installed, skipping connection"
             )
             return
@@ -97,7 +100,7 @@ class SolarControlClient:
         self._running = True
         self._main_loop = asyncio.get_running_loop()
         self._connection_task = asyncio.create_task(self._run())
-        print(f"SolarControlClient: Starting connection to {self.base_url}")
+        logger.info("SolarControlClient: Starting connection to %s", self.base_url)
 
     async def stop(self):
         """Stop the Socket.IO client and disconnect."""
@@ -118,7 +121,7 @@ class SolarControlClient:
             self._sio = None
 
         self._connected = False
-        print("SolarControlClient: Stopped")
+        logger.info("SolarControlClient: Stopped")
 
     async def reconnect(self) -> bool:
         """Force reconnection. Resets backoff and restarts the connection loop.
@@ -137,7 +140,7 @@ class SolarControlClient:
                 await self._connection_task
             except asyncio.CancelledError:
                 pass
-        print("SolarControlClient: Reconnect requested, restarting connection loop")
+        logger.info("SolarControlClient: Reconnect requested, restarting connection loop")
         self._connection_task = asyncio.create_task(self._run())
         return True
 
@@ -165,6 +168,7 @@ class SolarControlClient:
             ssl_verify=ssl_verify,
             http_session=http_session,
             handle_sigint=False,
+            ping_interval=host_settings.ws_ping_interval,
         )
 
         sio.register_namespace(_HostNamespace(self))
@@ -188,7 +192,7 @@ class SolarControlClient:
                 break
             except Exception as e:
                 if self._running:
-                    print(f"SolarControlClient: Connection error: {e}")
+                    logger.warning("SolarControlClient: Connection error: %s", e)
                     await asyncio.sleep(outer_backoff)
                     outer_backoff = min(outer_backoff * 2, reconnect_max_delay)
 
@@ -201,7 +205,7 @@ class SolarControlClient:
     def _on_connect(self):
         """Called when connected to /hosts namespace."""
         self._connected = True
-        print(f"SolarControlClient: Connected to {self.base_url}")
+        logger.info("SolarControlClient: Connected to %s", self.base_url)
         if self._registration_task and not self._registration_task.done():
             self._registration_task.cancel()
         self._registration_task = asyncio.create_task(self._send_registration())
@@ -225,15 +229,16 @@ class SolarControlClient:
         self._pending = False
         self.host_id = data.get("host_id")
         host_name = data.get("host_name", self.host_id)
-        print(f"SolarControlClient: Registered as '{host_name}' (id: {self.host_id})")
+        logger.info("SolarControlClient: Registered as '%s' (id: %s)", host_name, self.host_id)
         if was_pending:
             asyncio.create_task(self._post_approval_sync())
 
     def _on_pending(self, data: dict):
         """Handle pending event - host is waiting for admin approval."""
         self._pending = True
-        print(
-            f"SolarControlClient: Waiting for admin approval (pending_id: {data.get('pending_id', '?')})"
+        logger.info(
+            "SolarControlClient: Waiting for admin approval (pending_id: %s)",
+            data.get("pending_id", "?"),
         )
 
     def _on_rejected(self, data: dict):
@@ -246,7 +251,7 @@ class SolarControlClient:
         self._pending = False
         self._running = False
         reason = data.get("reason", "No reason given")
-        print(f"SolarControlClient: Registration rejected: {reason}. Stopping client.")
+        logger.warning("SolarControlClient: Registration rejected: %s. Stopping client.", reason)
 
     async def _send_registration(self):
         """Send registration event with instance list."""
@@ -303,7 +308,7 @@ class SolarControlClient:
         try:
             await self._sio.emit(event, data, namespace=self.NAMESPACE)
         except Exception as e:
-            print(f"SolarControlClient: Emit error: {e}")
+            logger.warning("SolarControlClient: Emit error: %s", e)
 
     async def send_log_batch(self, entries: List[dict]):
         """Send a batch of log messages to solar-control in a single emit."""
@@ -437,17 +442,16 @@ def init_clients(settings) -> List[SolarControlClient]:
     global solar_control_clients
 
     if not settings.solar_control_url:
-        print("SolarControlClient: SOLAR_CONTROL_URL not configured")
+        logger.info("SolarControlClient: SOLAR_CONTROL_URL not configured")
         return []
 
     if not settings.api_key:
-        print("SolarControlClient: API_KEY not configured")
+        logger.warning("SolarControlClient: API_KEY not configured")
         return []
 
-    # Single URL - take first if comma-separated
     url = settings.solar_control_url.split(",")[0].strip()
     if not url:
-        print("SolarControlClient: No valid URL found")
+        logger.warning("SolarControlClient: No valid URL found")
         return []
 
     solar_control_clients = [
@@ -458,7 +462,7 @@ def init_clients(settings) -> List[SolarControlClient]:
             insecure=settings.insecure,
         )
     ]
-    print("SolarControlClient: Configured 1 connection")
+    logger.info("SolarControlClient: Configured 1 connection")
     return solar_control_clients
 
 

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -88,7 +88,9 @@ class SolarControlClient:
     async def start(self):
         """Start the Socket.IO client and connect to solar-control."""
         if not self.control_url:
-            logger.info("SolarControlClient: No control URL configured, skipping connection")
+            logger.info(
+                "SolarControlClient: No control URL configured, skipping connection"
+            )
             return
 
         if not HAS_SOCKETIO:
@@ -140,7 +142,9 @@ class SolarControlClient:
                 await self._connection_task
             except asyncio.CancelledError:
                 pass
-        logger.info("SolarControlClient: Reconnect requested, restarting connection loop")
+        logger.info(
+            "SolarControlClient: Reconnect requested, restarting connection loop"
+        )
         self._connection_task = asyncio.create_task(self._run())
         return True
 
@@ -228,7 +232,9 @@ class SolarControlClient:
         self._pending = False
         self.host_id = data.get("host_id")
         host_name = data.get("host_name", self.host_id)
-        logger.info("SolarControlClient: Registered as '%s' (id: %s)", host_name, self.host_id)
+        logger.info(
+            "SolarControlClient: Registered as '%s' (id: %s)", host_name, self.host_id
+        )
         if was_pending:
             asyncio.create_task(self._post_approval_sync())
 
@@ -250,7 +256,9 @@ class SolarControlClient:
         self._pending = False
         self._running = False
         reason = data.get("reason", "No reason given")
-        logger.warning("SolarControlClient: Registration rejected: %s. Stopping client.", reason)
+        logger.warning(
+            "SolarControlClient: Registration rejected: %s. Stopping client.", reason
+        )
 
     async def _send_registration(self):
         """Send registration event with instance list."""

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -168,7 +168,6 @@ class SolarControlClient:
             ssl_verify=ssl_verify,
             http_session=http_session,
             handle_sigint=False,
-            ping_interval=host_settings.ws_ping_interval,
         )
 
         sio.register_namespace(_HostNamespace(self))


### PR DESCRIPTION
### Summary

This PR hardens **solar-host** for production use: thread-safe configuration persistence, bounded event queues, clearer HTTP semantics, safer subprocess and manifest handling, and structured logging instead of `print()`. It also fixes several edge cases that could cause silent failures, misleading responses, or resource leaks.

### Configuration and persistence

- **`ConfigManager`**: All reads/writes are protected by a `threading.Lock`. Saves are **atomic** (write to `*.json.tmp`, then `os.replace()`), reducing risk of truncated `config.json` on crash.
- **`parse_instance_config`**: Unknown `backend_type` now raises **`ValueError`** instead of silently coercing to llama.cpp.

### Process management

- **Bounded queues** (`MAX_QUEUE_SIZE = 10_000`) for batched log/state events; full queues drop events instead of growing without bound.
- **Flush/watchdog loops**: Broad silent `except` replaced with **`logger.exception`** and a short sleep to avoid tight error loops.
- **`start_instance`**: Retries use an **iterative** loop instead of recursion.
- **`stop_instance`**: Waits for the log reader thread (join with timeout) after the process exits.
- **`delete_instance`**: Defensively terminates any lingering tracked process before removing state.
- **`restart_instance`**: If `stop` fails and the instance is still **running/starting**, restart is **aborted**.
- **`auto_restart_running_instances`**: Sends **SIGTERM** to stale PIDs from interrupted runs before clearing state.

### Backends

- **HuggingFace**: `[COMPLETE]` log line parsing wrapped so malformed lines do not break the log thread; unknown `backend_type` raises **`RuntimeError`** instead of defaulting to causal.
- **Llama.cpp**: Removed unused `_re_prompt_eval_line` regex.

### API and HTTP behavior

- **Startup**: Safe handling when `API_KEY` is shorter than 4 characters (no `IndexError`).
- **`GET /`**: `supported_backends` is derived from the **`BackendType`** enum (includes **`huggingface_embedding`**).
- **`GET /memory`**: Returns **503** if memory info is missing or malformed (no more misleading zeros).
- **`POST /reconnect`**: Returns **503** when there is no client or reconnection cannot be triggered; **200** for `already_connected` / `reconnecting` as appropriate.
- **CORS**: **`allow_credentials=False`** with `allow_origins=["*"]`** (avoids invalid browser combinations).
- **`GET .../last-generation`**: Invalid **`after`** query returns **400** instead of skipping the filter silently.

### Memory and models

- **NVIDIA VRAM**: `nvmlShutdown()` is always called after `nvmlInit()` in a **`try`/`finally`** block.
- **Linux without NVIDIA**: Falls back to **system RAM** via `psutil` when VRAM is unavailable.
- **`pull_model`**: On manifest cache hit, verifies the on-disk path exists; **stale manifest entries** are removed if files are missing.

### WebSocket client

- **`ping_interval` was not passed to `socketio.AsyncClient`**: python-socketio’s client does not accept that constructor argument in the versions used in testing; the server drives ping behavior. That change was **reverted** after integration testing showed a **`TypeError`** at runtime.

### Logging

- Replaced **`print()`** usage across the touched modules with the **`logging`** module for consistent, level-based output.

### Testing

- Manually exercised on **ai02**: health, auth, instance start/stop/restart, inference, logs/state/metrics, rapid stop/start cycles, `/reconnect`, and config file integrity. **Note:** `llama-server` must be on **`PATH`** (e.g. as in `~/.bashrc` on that host) for llama.cpp instances to start.