### PR TITLE
feat(models): validate disk space before model pull (S-018)

### DIFF
--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     max_retries: int = 2
     log_buffer_size: int = 1000
     models_dir: str = "./models"
+    min_free_disk_gb: float = 2.0
 
     # Solar-control connection settings (WebSocket 2.0)
     # URL(s) to solar-control's host channel endpoint

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -8,21 +8,23 @@ The manifest file (MODELS_DIR/manifest.json) is the single source of truth for
 cache detection.
 """
 
-import errno
 import json
 import logging
 import os
 import re
 import shutil
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
+import pebble
 from pydantic import BaseModel
 
 from solar_host.config import settings
+from solar_host.memory_monitor import get_disk_info
 
 logger = logging.getLogger(__name__)
 
@@ -300,6 +302,7 @@ def pull_model(
     harbor_ref: Optional[str] = None,
     model_id: Optional[str] = None,
     digest: Optional[str] = None,
+    size_bytes: Optional[int] = None,
 ) -> dict:
     """Download a model from Harbor or HuggingFace Hub and record it in the manifest.
 
@@ -355,6 +358,22 @@ def pull_model(
 
         target_dir = get_models_dir() / slug
 
+        # 3.5 Proactive disk space validation.
+        disk = get_disk_info(str(get_models_dir()))
+        if disk:
+            available_gb = disk["available_gb"]
+            required_gb = (
+                (size_bytes / (1024**3)) if size_bytes else settings.min_free_disk_gb
+            )
+
+            if available_gb < required_gb:
+                raise ModelPullError(
+                    507,
+                    "insufficient_storage",
+                    f"Insufficient disk space. Available: {available_gb:.2f} GB, required: {required_gb:.2f} GB.",
+                    source_uri,
+                )
+
         # 4. Validate credentials before touching the filesystem.
         if source == "harbor":
             if not all(
@@ -376,23 +395,44 @@ def pull_model(
             logger.warning("Removing stale model directory before pull: %s", target_dir)
             shutil.rmtree(target_dir, ignore_errors=True)
 
-        # 6. Download — wrap in try/except to clean up on failure.
+        # 6. Download — monitored via Pebble to allow aborting on disk-full.
         try:
-            if source == "harbor":
-                _pull_harbor(harbor_ref or "", target_dir, source_uri)
-            else:
-                _pull_huggingface(model_id or "", target_dir, source_uri)
+            with pebble.ProcessPool(max_workers=1) as pool:
+                if source == "harbor":
+                    future = pool.schedule(
+                        _pull_harbor, args=(harbor_ref or "", target_dir, source_uri)
+                    )
+                else:
+                    future = pool.schedule(
+                        _pull_huggingface, args=(model_id or "", target_dir, source_uri)
+                    )
+
+                while not future.done():
+                    time.sleep(2)
+                    disk = get_disk_info(str(get_models_dir()))
+                    if disk and disk["available_gb"] < settings.min_free_disk_gb:
+                        future.cancel()
+                        logger.error(
+                            "Aborting pull for %s: disk space dropped below %s GB",
+                            source_uri,
+                            settings.min_free_disk_gb,
+                        )
+                        raise ModelPullError(
+                            507,
+                            "insufficient_storage",
+                            "Insufficient disk space during download.",
+                            source_uri,
+                        )
+
+                # Propagate any exceptions from the worker process.
+                future.result()
         except ModelPullError:
             shutil.rmtree(target_dir, ignore_errors=True)
             raise
-        except OSError as exc:
+        except pebble.ProcessExpired as exc:
             shutil.rmtree(target_dir, ignore_errors=True)
-            if exc.errno == errno.ENOSPC:
-                raise ModelPullError(
-                    507, "insufficient_storage", "Insufficient disk space.", source_uri
-                ) from exc
             raise ModelPullError(
-                500, "model_pull_failed", str(exc), source_uri
+                500, "model_pull_failed", f"Download process expired: {exc}", source_uri
             ) from exc
         except Exception as exc:
             shutil.rmtree(target_dir, ignore_errors=True)

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -88,6 +88,7 @@ class PullRequest(BaseModel):
     harbor_ref: Optional[str] = None
     model_id: Optional[str] = None
     digest: Optional[str] = None
+    size_bytes: Optional[int] = None
 
 
 class PullResponse(BaseModel):
@@ -125,6 +126,12 @@ async def pull_model(req: PullRequest) -> Union[PullResponse, JSONResponse]:
     the manifest is updated atomically, and the new path is returned.
 
     The caller blocks until the model is fully available.
+
+    Contract for Distribution (S-019):
+    Before issuing a pull, solar-control should query the target host's /health
+    endpoint to check disk.available_gb. If the model size is known, it should
+    be passed as size_bytes here for proactive validation. If available space
+    drops below min_free_disk_gb during download, the pull will be aborted.
     """
     # Validate conditional required fields before doing any I/O.
     if req.source == "harbor" and not req.harbor_ref:
@@ -144,6 +151,7 @@ async def pull_model(req: PullRequest) -> Union[PullResponse, JSONResponse]:
             harbor_ref=req.harbor_ref,
             model_id=req.model_id,
             digest=req.digest,
+            size_bytes=req.size_bytes,
         )
     except ModelPullError as exc:
         return JSONResponse(

--- a/solar_host/servers/hf_server.py
+++ b/solar_host/servers/hf_server.py
@@ -562,9 +562,7 @@ def _normalize_messages_for_processor(
                 parts.append({"type": "text", "text": part.get("text", "")})
             elif ptype == "image_url":
                 image_url = part.get("image_url", {})
-                url = (
-                    image_url.get("url") if isinstance(image_url, dict) else image_url
-                )
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
                 if not url:
                     raise ValueError("image_url part missing 'url'")
                 images.append(_load_image_from_url(url))
@@ -576,7 +574,9 @@ def _normalize_messages_for_processor(
     return norm_messages, images
 
 
-async def _chat_completion_causal(request: ChatCompletionRequest) -> ChatCompletionResponse:
+async def _chat_completion_causal(
+    request: ChatCompletionRequest,
+) -> ChatCompletionResponse:
     """Chat completion implementation for causal (text-only) models."""
     state.ensure_loaded()
     model = state.model
@@ -659,7 +659,9 @@ async def _chat_completion_causal(request: ChatCompletionRequest) -> ChatComplet
     )
 
 
-async def _chat_completion_vision(request: ChatCompletionRequest) -> ChatCompletionResponse:
+async def _chat_completion_vision(
+    request: ChatCompletionRequest,
+) -> ChatCompletionResponse:
     """Chat completion implementation for vision/multimodal models."""
     state.ensure_loaded()
     model = state.model


### PR DESCRIPTION
## Description
Adds proactive and runtime disk checks for `POST /models/pull` so pulls fail fast with 507 when space is insufficient, instead of partial downloads or filling the disk. Aligns with S-003 by using the same `get_disk_info` path as `/health` for the models directory.

## Changes
- `Settings`: new `min_free_disk_gb` (default 2.0) for unknown-size pulls and runtime abort threshold.
- `PullRequest`: optional `size_bytes`; route passes it into `pull_model`.
- `pull_model`: before download, if disk info is available, compare `available_gb` to required size (`size_bytes` in GB, else `min_free_disk_gb`); on failure return 507 with message `Insufficient disk space. Available: X GB, required: Y GB.`
- Downloads run in a `pebble.ProcessPool` worker while the parent polls `get_disk_info`; if `available_gb < min_free_disk_gb`, cancel the future and raise 507 with a during-download message.
- `pull_model` docstring: S-019 contract — solar-control may call `/health` for `disk.available_gb` before pull and may pass `size_bytes` when known.

## Related Issues
Closes #15 