### PR TITLE
feat(host): accept model_source URIs and resolve local:// for instances (S-010)

### DIFF
--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 class Settings(BaseSettings):
     """Application settings."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     api_key: str = "change-me-please"
     host: str = "0.0.0.0"
@@ -91,12 +93,64 @@ def migrate_config_data(config_data: Dict[str, Any]) -> Dict[str, Any]:
     return config_data
 
 
+def resolve_model_source(model_source: str) -> str:
+    """Resolve a model source URI to a filesystem path.
+
+    Supported URIs:
+    - local://<path>: Relative to settings.models_dir
+    - local:///<path>: Absolute path (must be within settings.models_dir)
+
+    Rejected URIs (must be pulled first):
+    - repo://...
+    - huggingface://...
+    """
+    if model_source.startswith("repo://") or model_source.startswith("huggingface://"):
+        raise ValueError(
+            "Model must be resolved via POST /models/pull before instance creation. "
+            "Use local:// or provide model/model_id path."
+        )
+
+    if not model_source.startswith("local://"):
+        # Not a URI, return as is (could be a plain path)
+        return model_source
+
+    path_part = model_source[len("local://") :]
+    models_dir = Path(settings.models_dir).resolve()
+
+    if path_part.startswith("/"):
+        # Absolute path local:///path
+        resolved_path = Path(path_part).resolve()
+    else:
+        # Relative path local://path
+        resolved_path = (models_dir / path_part).resolve()
+
+    # Security check: must be within models_dir
+    try:
+        resolved_path.relative_to(models_dir)
+    except ValueError:
+        raise ValueError(
+            f"Resolved path {resolved_path} is outside of MODELS_DIR ({models_dir})"
+        )
+
+    return str(resolved_path)
+
+
 def parse_instance_config(config_data: Dict[str, Any]) -> Any:
     """Parse config data into the appropriate config type based on backend_type."""
     # Migrate first
     config_data = migrate_config_data(config_data)
 
     backend_type = config_data.get("backend_type", "llamacpp")
+
+    # Resolve model_source if present
+    model_source = config_data.get("model_source")
+    if model_source:
+        resolved_path = resolve_model_source(model_source)
+        if backend_type == "llamacpp":
+            config_data["model"] = resolved_path
+        else:
+            # All HuggingFace types use model_id
+            config_data["model_id"] = resolved_path
 
     if backend_type == "llamacpp":
         return LlamaCppConfig(**config_data)

--- a/solar_host/models/huggingface.py
+++ b/solar_host/models/huggingface.py
@@ -27,10 +27,20 @@ class HuggingFaceCausalConfig(BaseModel):
     backend_type: Literal["huggingface_causal"] = Field(
         default="huggingface_causal", description="Backend type identifier"
     )
-    model_id: str = Field(
-        ...,
+    model_source: Optional[str] = Field(
+        default=None, description="Model source URI (e.g. local://model_dir)"
+    )
+    model_id: Optional[str] = Field(
+        default=None,
         description="HuggingFace model ID or local path (e.g., 'meta-llama/Llama-2-7b-hf')",
     )
+
+    @model_validator(mode="after")
+    def check_model_id_or_source(self) -> "HuggingFaceCausalConfig":
+        if not self.model_id and not self.model_source:
+            raise ValueError("Either 'model_id' or 'model_source' must be provided")
+        return self
+
     alias: str = Field(..., description="Model alias (e.g., llama2:7b)")
     device: str = Field(
         default="auto", description="Device to run on: auto, cuda, mps (Mac), cpu"
@@ -67,7 +77,19 @@ class HuggingFaceClassificationConfig(BaseModel):
     backend_type: Literal["huggingface_classification"] = Field(
         default="huggingface_classification", description="Backend type identifier"
     )
-    model_id: str = Field(..., description="HuggingFace model ID or local path")
+    model_source: Optional[str] = Field(
+        default=None, description="Model source URI (e.g. local://model_dir)"
+    )
+    model_id: Optional[str] = Field(
+        default=None, description="HuggingFace model ID or local path"
+    )
+
+    @model_validator(mode="after")
+    def check_model_id_or_source(self) -> "HuggingFaceClassificationConfig":
+        if not self.model_id and not self.model_source:
+            raise ValueError("Either 'model_id' or 'model_source' must be provided")
+        return self
+
     alias: str = Field(..., description="Model alias (e.g., classifier:deberta)")
     device: str = Field(
         default="auto", description="Device to run on: auto, cuda, mps (Mac), cpu"
@@ -106,10 +128,20 @@ class HuggingFaceEmbeddingConfig(BaseModel):
     backend_type: Literal["huggingface_embedding"] = Field(
         default="huggingface_embedding", description="Backend type identifier"
     )
-    model_id: str = Field(
-        ...,
+    model_source: Optional[str] = Field(
+        default=None, description="Model source URI (e.g. local://model_dir)"
+    )
+    model_id: Optional[str] = Field(
+        default=None,
         description="HuggingFace model ID or local path (e.g., 'sentence-transformers/all-MiniLM-L6-v2')",
     )
+
+    @model_validator(mode="after")
+    def check_model_id_or_source(self) -> "HuggingFaceEmbeddingConfig":
+        if not self.model_id and not self.model_source:
+            raise ValueError("Either 'model_id' or 'model_source' must be provided")
+        return self
+
     alias: str = Field(..., description="Model alias (e.g., embed:minilm)")
     device: str = Field(
         default="auto", description="Device to run on: auto, cuda, mps (Mac), cpu"
@@ -151,10 +183,20 @@ class HuggingFaceVisionConfig(BaseModel):
     backend_type: Literal["huggingface_vision"] = Field(
         default="huggingface_vision", description="Backend type identifier"
     )
-    model_id: str = Field(
-        ...,
+    model_source: Optional[str] = Field(
+        default=None, description="Model source URI (e.g. local://model_dir)"
+    )
+    model_id: Optional[str] = Field(
+        default=None,
         description="HuggingFace model ID or local path (e.g., 'Qwen/Qwen2.5-VL-7B-Instruct')",
     )
+
+    @model_validator(mode="after")
+    def check_model_id_or_source(self) -> "HuggingFaceVisionConfig":
+        if not self.model_id and not self.model_source:
+            raise ValueError("Either 'model_id' or 'model_source' must be provided")
+        return self
+
     alias: str = Field(..., description="Model alias (e.g., qwen-vl:7b)")
     device: str = Field(
         default="auto", description="Device to run on: auto, cuda, mps (Mac), cpu"

--- a/solar_host/models/llamacpp.py
+++ b/solar_host/models/llamacpp.py
@@ -25,7 +25,19 @@ class LlamaCppConfig(BaseModel):
             data.pop("api_key", None)
         return data
 
-    model: str = Field(..., description="Path to the GGUF model file")
+    model_source: Optional[str] = Field(
+        default=None, description="Model source URI (e.g. local://path/to/model.gguf)"
+    )
+    model: Optional[str] = Field(
+        default=None, description="Path to the GGUF model file"
+    )
+
+    @model_validator(mode="after")
+    def check_model_or_source(self) -> "LlamaCppConfig":
+        if not self.model and not self.model_source:
+            raise ValueError("Either 'model' or 'model_source' must be provided")
+        return self
+
     mmproj: Optional[str] = Field(
         default=None,
         description="Path to multimodal projector GGUF file for vision models",

--- a/tests/test_model_source_resolution.py
+++ b/tests/test_model_source_resolution.py
@@ -1,0 +1,99 @@
+"""Tests for model source URI resolution and instance configuration parsing."""
+
+import pytest
+from pathlib import Path
+from solar_host.config import resolve_model_source, parse_instance_config
+from solar_host.models.llamacpp import LlamaCppConfig
+from solar_host.models.huggingface import HuggingFaceCausalConfig
+
+
+@pytest.fixture
+def mock_models_dir(tmp_path: Path, monkeypatch):
+    """Point settings.models_dir at a temporary directory for tests."""
+    models_dir = (tmp_path / "models").resolve()
+    models_dir.mkdir()
+    # Need to monkeypatch where it's used
+    monkeypatch.setattr("solar_host.config.settings.models_dir", str(models_dir))
+    return models_dir
+
+
+class TestModelSourceResolution:
+    def test_resolve_plain_path(self):
+        # Plain path should be returned as-is
+        path = "/tmp/model.gguf"
+        assert resolve_model_source(path) == path
+
+    def test_resolve_local_relative(self, mock_models_dir):
+        # local://path resolves relative to MODELS_DIR
+        model_rel_path = "subdir/model.gguf"
+        uri = f"local://{model_rel_path}"
+        expected = str((mock_models_dir / model_rel_path).resolve())
+        assert resolve_model_source(uri) == expected
+
+    def test_resolve_local_absolute_inside(self, mock_models_dir):
+        # local:///<abs_path> resolves as absolute but must be inside MODELS_DIR
+        abs_path = (mock_models_dir / "abs_model.gguf").resolve()
+        uri = f"local://{abs_path}"
+        assert resolve_model_source(uri) == str(abs_path)
+
+    def test_resolve_local_absolute_outside_raises(self, tmp_path, mock_models_dir):
+        # local:///<path> outside MODELS_DIR raises ValueError
+        outside_path = (tmp_path / "outside.gguf").resolve()
+        uri = f"local://{outside_path}"
+        with pytest.raises(ValueError, match="outside of MODELS_DIR"):
+            resolve_model_source(uri)
+
+    def test_reject_repo_uri(self):
+        with pytest.raises(
+            ValueError, match="Model must be resolved via POST /models/pull"
+        ):
+            resolve_model_source("repo://some-model:v1")
+
+    def test_reject_huggingface_uri(self):
+        with pytest.raises(
+            ValueError, match="Model must be resolved via POST /models/pull"
+        ):
+            resolve_model_source("huggingface://some-org/some-model")
+
+
+class TestParseInstanceConfigWithModelSource:
+    def test_llamacpp_with_model_source(self, mock_models_dir):
+        config_data = {
+            "backend_type": "llamacpp",
+            "model_source": "local://model.gguf",
+            "alias": "test-alias",
+        }
+        config = parse_instance_config(config_data)
+        assert isinstance(config, LlamaCppConfig)
+        assert config.model == str((mock_models_dir / "model.gguf").resolve())
+        assert config.model_source == "local://model.gguf"
+
+    def test_huggingface_with_model_source(self, mock_models_dir):
+        config_data = {
+            "backend_type": "huggingface_causal",
+            "model_source": "local://hf-model",
+            "alias": "hf-alias",
+        }
+        config = parse_instance_config(config_data)
+        assert isinstance(config, HuggingFaceCausalConfig)
+        assert config.model_id == str((mock_models_dir / "hf-model").resolve())
+        assert config.model_source == "local://hf-model"
+
+    def test_backward_compatibility_llamacpp(self):
+        config_data = {
+            "backend_type": "llamacpp",
+            "model": "/path/to/model.gguf",
+            "alias": "test-alias",
+        }
+        config = parse_instance_config(config_data)
+        assert isinstance(config, LlamaCppConfig)
+        assert config.model == "/path/to/model.gguf"
+        assert config.model_source is None
+
+    def test_missing_both_raises(self):
+        config_data = {"backend_type": "llamacpp", "alias": "test-alias"}
+        # parse_instance_config calls LlamaCppConfig(**config_data) which will trigger validator
+        with pytest.raises(
+            ValueError, match="Either 'model' or 'model_source' must be provided"
+        ):
+            parse_instance_config(config_data)


### PR DESCRIPTION
## Description

Solar Host instance configs previously only accepted a GGUF path (`model`) or HuggingFace id/path (`model_id`). This change adds optional `model_source` so callers can pass a `local://` URI after models are materialized under `MODELS_DIR` (e.g. after solar-control calls `POST /models/pull`). `repo://` and `huggingface://` are rejected at instance creation with a clear message directing callers to pull first. Resolution happens in `parse_instance_config`, so backend runners keep using resolved `model` / `model_id` paths. `Settings` ignores unknown env keys so local/dev `.env` files do not break startup.

## Changes

- Add optional `model_source` to `LlamaCppConfig` and all HuggingFace config models; make `model` / `model_id` optional when `model_source` is present; validators require at least one of the pair.
- Add `resolve_model_source()` in `solar_host/config.py`: resolve `local://` relative to `MODELS_DIR` or absolute `local:///` paths constrained under `MODELS_DIR`; reject `repo://` and `huggingface://` with the spec error text.
- Extend `parse_instance_config()` to resolve `model_source` into `model` (llama.cpp) or `model_id` (HF) before constructing config objects.
- Set `SettingsConfigDict(..., extra="ignore")` so stray environment variables do not fail `Settings()` validation.
- Add `tests/test_model_source_resolution.py` covering resolution, boundary checks, rejections, `parse_instance_config` integration, backward compatibility, and missing-field validation.

## Related Issues

Closes #10 