### PR TITLE
feat(models): accept and persist Data Repository metadata on pull (D-016)

### DIFF
--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -37,7 +37,13 @@ MANIFEST_TMP_FILENAME = "manifest.json.tmp"
 
 
 class ManifestEntry(BaseModel):
-    """A single downloaded model tracked in the manifest."""
+    """A single downloaded model tracked in the manifest.
+
+    The ``category``, ``name``, ``version``, ``checksum`` and ``metadata``
+    fields are optional and were introduced with D-016 to carry through
+    authoritative metadata supplied by Data Repository. They are absent on
+    entries created before that change; readers must treat them as optional.
+    """
 
     slug: str
     source_uri: str
@@ -45,6 +51,11 @@ class ManifestEntry(BaseModel):
     size_bytes: int
     digest: Optional[str] = None
     downloaded_at: str
+    category: Optional[str] = None
+    name: Optional[str] = None
+    version: Optional[str] = None
+    checksum: Optional[str] = None
+    metadata: Optional[dict] = None
 
 
 class Manifest(BaseModel):
@@ -304,6 +315,11 @@ def pull_model(
     model_id: Optional[str] = None,
     digest: Optional[str] = None,
     size_bytes: Optional[int] = None,
+    category: Optional[str] = None,
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    checksum: Optional[str] = None,
+    metadata: Optional[dict] = None,
 ) -> dict:
     """Download a model from Harbor or HuggingFace Hub and record it in the manifest.
 
@@ -469,6 +485,11 @@ def pull_model(
             size_bytes=size_bytes,
             digest=digest,
             downloaded_at=datetime.now(timezone.utc).isoformat(),
+            category=category,
+            name=name,
+            version=version,
+            checksum=checksum,
+            metadata=metadata,
         )
         with _manifest_lock:
             add_manifest_entry(entry)

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -36,7 +36,14 @@ router = APIRouter(prefix="/models", tags=["models"])
 
 
 class ModelEntry(BaseModel):
-    """A single model entry returned by GET /models."""
+    """A single model entry returned by GET /models.
+
+    ``category``, ``model_name``, ``version`` and ``metadata`` are populated
+    from the manifest when the model was pulled with Data Repository
+    metadata (D-016); they are omitted on older entries.
+    """
+
+    model_config = {"protected_namespaces": ()}
 
     name: str
     path: str
@@ -44,6 +51,10 @@ class ModelEntry(BaseModel):
     source_uri: Optional[str] = None
     checksum: Optional[str] = None
     downloaded_at: Optional[str] = None
+    category: Optional[str] = None
+    model_name: Optional[str] = None
+    version: Optional[str] = None
+    metadata: Optional[dict] = None
 
 
 def _manifest_to_entries() -> List[ModelEntry]:
@@ -54,8 +65,12 @@ def _manifest_to_entries() -> List[ModelEntry]:
             path=e.path,
             size_bytes=e.size_bytes,
             source_uri=e.source_uri,
-            checksum=e.digest,
+            checksum=e.checksum or e.digest,
             downloaded_at=e.downloaded_at,
+            category=e.category,
+            model_name=e.name,
+            version=e.version,
+            metadata=e.metadata,
         )
         for e in manifest.models
     ]
@@ -79,7 +94,14 @@ async def list_models() -> List[ModelEntry]:
 
 
 class PullRequest(BaseModel):
-    """Request body for POST /models/pull (spec Section 3.6)."""
+    """Request body for POST /models/pull (spec Section 3.6).
+
+    The ``category``, ``name``, ``version``, ``checksum`` and ``metadata``
+    fields were added with D-016 so solar-control can forward the
+    authoritative metadata returned by Data Repository. They are optional and
+    stored on the manifest entry verbatim when present; the host does not
+    consult them for pull behaviour.
+    """
 
     model_config = {"protected_namespaces": ()}
 
@@ -89,6 +111,11 @@ class PullRequest(BaseModel):
     model_id: Optional[str] = None
     digest: Optional[str] = None
     size_bytes: Optional[int] = None
+    category: Optional[str] = None
+    name: Optional[str] = None
+    version: Optional[str] = None
+    checksum: Optional[str] = None
+    metadata: Optional[dict] = None
 
 
 class PullResponse(BaseModel):
@@ -152,6 +179,11 @@ async def pull_model(req: PullRequest) -> Union[PullResponse, JSONResponse]:
             model_id=req.model_id,
             digest=req.digest,
             size_bytes=req.size_bytes,
+            category=req.category,
+            name=req.name,
+            version=req.version,
+            checksum=req.checksum,
+            metadata=req.metadata,
         )
     except ModelPullError as exc:
         return JSONResponse(

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -349,6 +349,78 @@ class TestHarborPull:
         assert resp2.json()["cached"] is True
         mock_pull.assert_not_called()
 
+    def test_harbor_pull_persists_repo_metadata(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """D-016: Data Repository metadata fields round-trip into the manifest."""
+        body = {
+            **_harbor_body(),
+            "category": "model",
+            "name": "iris-osl",
+            "version": "v3",
+            "checksum": "sha256:abc123",
+            "metadata": {"format": "gguf", "quantization": "Q4_K_M"},
+        }
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        entry = get_manifest_entry("repo://iris-osl:v3")
+        assert entry is not None
+        assert entry.category == "model"
+        assert entry.name == "iris-osl"
+        assert entry.version == "v3"
+        assert entry.checksum == "sha256:abc123"
+        assert entry.metadata == {"format": "gguf", "quantization": "Q4_K_M"}
+
+    def test_repo_metadata_surfaced_in_get_models(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """GET /models returns the Data Repository metadata for D-016 pulls."""
+        body = {
+            **_harbor_body(),
+            "category": "model",
+            "name": "iris-osl",
+            "version": "v3",
+            "metadata": {"format": "gguf"},
+        }
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            client.post("/models/pull", json=body, headers=_headers())
+
+        resp = client.get("/models", headers=_headers())
+        assert resp.status_code == 200
+        entries = [m for m in resp.json() if m["name"] == "repo--iris-osl--v3"]
+        assert len(entries) == 1
+        m = entries[0]
+        assert m["category"] == "model"
+        assert m["model_name"] == "iris-osl"
+        assert m["version"] == "v3"
+        assert m["metadata"] == {"format": "gguf"}
+
+    def test_harbor_pull_without_repo_metadata_still_works(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Pulls that omit the D-016 fields are still accepted (back-compat)."""
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        entry = get_manifest_entry("repo://iris-osl:v3")
+        assert entry is not None
+        assert entry.category is None
+        assert entry.name is None
+        assert entry.version is None
+        assert entry.metadata is None
+
 
 # ---------------------------------------------------------------------------
 # HuggingFace pull (cache miss)


### PR DESCRIPTION
## Description

Companion change for solar-control's D-016 (`repo://` resolver completion). Extends `POST /models/pull` and the manifest to accept and persist the authoritative metadata that solar-control forwards from Data Repository — without it, those fields are silently dropped on arrival.

The host does not consult the new fields for pull behavior; it just records them so they can be read back via `GET /models` and inspected operationally.

## Changes

- `solar_host/routes/models.py`
  - `PullRequest` accepts five new optional fields: `category`, `name`, `version`, `checksum`, `metadata`.
  - `ModelEntry` (response body for `GET /models`) surfaces the same fields, exposing `name` from the manifest as `model_name` to avoid colliding with the existing slug-based `name`.
- `solar_host/models_manager.py`
  - `ManifestEntry` carries the new optional fields.
  - `pull_model()` threads them through and persists them on the manifest entry.
- `tests/test_pull.py`
  - Verifies metadata round-trips into the manifest.
  - Verifies metadata is surfaced via `GET /models`.
  - Verifies pulls without the new fields still succeed (backwards compat).

## Backwards compatibility

- All new fields are `Optional[...] = None`, so existing callers and existing manifest entries continue to work unchanged.
- `ModelEntry.checksum` falls back to the pre-existing `entry.digest` when the new `entry.checksum` is not set, so historic entries still surface a checksum in `GET /models`.
- No migration step is required for existing `manifest.json` files.

## Related

- Pairs with DamitDev/solar-control#48. Without this change, solar-control's metadata forwarding is a no-op on the host side.
- Depends on: S-015 (`POST /models/pull` contract).

## Test plan

- [x] `pytest` — full suite (116 tests, +3 new).
- [x] Manual: end-to-end `repo://` pull from solar-control on `feature/D-016`, then `GET /models` on the host and confirm `category`, `model_name`, `version`, and `metadata` are populated.
- [x] Manual: pull a `huggingface://` URI from solar-control (no metadata path) and confirm `GET /models` still returns the entry with the new fields as `null`.