### PR TITLE
feat(models): add instance priority levels and ownership fields (S-036)

### DIFF
--- a/solar_host/models/__init__.py
+++ b/solar_host/models/__init__.py
@@ -8,6 +8,7 @@ from solar_host.models.base import (
     BackendType,
     InstanceStatus,
     InstancePhase,
+    InstancePriority,
     Instance,
     InstanceCreate,
     InstanceUpdate,
@@ -45,6 +46,7 @@ __all__ = [
     "BackendType",
     "InstanceStatus",
     "InstancePhase",
+    "InstancePriority",
     # Config types
     "InstanceConfig",
     "LlamaCppConfig",

--- a/solar_host/models/base.py
+++ b/solar_host/models/base.py
@@ -34,6 +34,14 @@ class InstancePhase(str, Enum):
     GENERATING = "generating"
 
 
+class InstancePriority(str, Enum):
+    """Priority level for inference instances (S-036)."""
+
+    PRODUCTION = "production"
+    STAGING = "staging"
+    EPHEMERAL = "ephemeral"
+
+
 class LogMessage(BaseModel):
     """Log message with sequence number."""
 
@@ -120,6 +128,20 @@ class Instance(BaseModel):
     error_message: Optional[str] = None
     retry_count: int = 0
 
+    # Priority and ownership (S-036)
+    priority: InstancePriority = Field(
+        default=InstancePriority.PRODUCTION,
+        description="Instance priority for placement and eviction decisions",
+    )
+    managed_by: Optional[str] = Field(
+        default=None,
+        description="Owner subsystem (e.g. 'intent' for reconciler-managed instances)",
+    )
+    intent_id: Optional[str] = Field(
+        default=None,
+        description="Owning intent ID (set iff managed_by == 'intent')",
+    )
+
     # Supported API endpoints for this instance (populated by backend runner)
     supported_endpoints: List[str] = Field(default_factory=list)
 
@@ -136,6 +158,9 @@ class InstanceCreate(BaseModel):
     """
 
     config: Any  # InstanceConfig
+    priority: Optional[str] = None
+    managed_by: Optional[str] = None
+    intent_id: Optional[str] = None
 
 
 class InstanceUpdate(BaseModel):

--- a/solar_host/process_manager.py
+++ b/solar_host/process_manager.py
@@ -18,6 +18,7 @@ import threading
 from solar_host.models import (
     Instance,
     InstanceStatus,
+    InstancePriority,
     LogMessage,
     InstanceRuntimeState,
     InstanceStateEvent,
@@ -628,7 +629,13 @@ class ProcessManager:
         await asyncio.sleep(1)
         return await self.start_instance(instance_id)
 
-    def create_instance(self, config) -> Instance:
+    def create_instance(
+        self,
+        config,
+        priority: str | None = None,
+        managed_by: str | None = None,
+        intent_id: str | None = None,
+    ) -> Instance:
         """Create a new instance."""
         # Parse config if it's a dict (from FastAPI request body)
         if isinstance(config, dict):
@@ -654,6 +661,9 @@ class ProcessManager:
             config=config,
             status=InstanceStatus.STOPPED,
             supported_endpoints=supported_endpoints,
+            priority=InstancePriority(priority) if priority else InstancePriority.PRODUCTION,
+            managed_by=managed_by,
+            intent_id=intent_id,
         )
         config_manager.add_instance(instance)
 

--- a/solar_host/process_manager.py
+++ b/solar_host/process_manager.py
@@ -661,7 +661,9 @@ class ProcessManager:
             config=config,
             status=InstanceStatus.STOPPED,
             supported_endpoints=supported_endpoints,
-            priority=InstancePriority(priority) if priority else InstancePriority.PRODUCTION,
+            priority=(
+                InstancePriority(priority) if priority else InstancePriority.PRODUCTION
+            ),
             managed_by=managed_by,
             intent_id=intent_id,
         )

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -7,6 +7,7 @@ from solar_host.models import (
     InstanceUpdate,
     InstanceResponse,
     InstanceStatus,
+    InstancePriority,
     InstanceRuntimeState,
     GenerationMetrics,
     LogMessage,
@@ -20,8 +21,21 @@ router = APIRouter(prefix="/instances", tags=["instances"])
 @router.post("", response_model=InstanceResponse)
 async def create_instance(data: InstanceCreate):
     """Create a new model instance (llama.cpp or HuggingFace)"""
+    # Validate priority if provided (S-036)
+    VALID_PRIORITIES = {p.value for p in InstancePriority}
+    if data.priority is not None and data.priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid priority '{data.priority}'. Must be one of: {', '.join(sorted(VALID_PRIORITIES))}",
+        )
+
     try:
-        instance = process_manager.create_instance(data.config)
+        instance = process_manager.create_instance(
+            data.config,
+            priority=data.priority,
+            managed_by=data.managed_by,
+            intent_id=data.intent_id,
+        )
         return InstanceResponse(
             instance=instance, message=f"Instance {instance.id} created successfully"
         )

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -279,7 +279,9 @@ class SolarControlClient:
                     "backend_type": getattr(
                         instance.config, "backend_type", "llamacpp"
                     ),
-                    "priority": instance.priority.value if instance.priority else "production",
+                    "priority": (
+                        instance.priority.value if instance.priority else "production"
+                    ),
                     "managed_by": instance.managed_by,
                     "intent_id": instance.intent_id,
                 }
@@ -430,7 +432,9 @@ class SolarControlClient:
                     "backend_type": getattr(
                         instance.config, "backend_type", "llamacpp"
                     ),
-                    "priority": instance.priority.value if instance.priority else "production",
+                    "priority": (
+                        instance.priority.value if instance.priority else "production"
+                    ),
                     "managed_by": instance.managed_by,
                     "intent_id": instance.intent_id,
                 }

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -279,6 +279,9 @@ class SolarControlClient:
                     "backend_type": getattr(
                         instance.config, "backend_type", "llamacpp"
                     ),
+                    "priority": instance.priority.value if instance.priority else "production",
+                    "managed_by": instance.managed_by,
+                    "intent_id": instance.intent_id,
                 }
             )
 
@@ -427,6 +430,9 @@ class SolarControlClient:
                     "backend_type": getattr(
                         instance.config, "backend_type", "llamacpp"
                     ),
+                    "priority": instance.priority.value if instance.priority else "production",
+                    "managed_by": instance.managed_by,
+                    "intent_id": instance.intent_id,
                 }
             )
 

--- a/tests/test_instance_priority.py
+++ b/tests/test_instance_priority.py
@@ -28,7 +28,11 @@ class TestInstancePriorityDefault:
     def test_default_is_production(self):
         instance = Instance(
             id="test-default",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
         )
         assert instance.priority == InstancePriority.PRODUCTION
 
@@ -37,7 +41,11 @@ class TestInstancePriorityDefault:
         with pytest.raises(ValidationError):
             Instance(
                 id="test-none",
-                config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+                config={
+                    "backend_type": "llamacpp",
+                    "model": "/tmp/test.gguf",
+                    "alias": "test",
+                },
                 priority=None,
             )
 
@@ -46,7 +54,11 @@ class TestInstancePriorityDefault:
         instance = Instance.model_validate(
             {
                 "id": "test-omitted",
-                "config": {"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+                "config": {
+                    "backend_type": "llamacpp",
+                    "model": "/tmp/test.gguf",
+                    "alias": "test",
+                },
             }
         )
         assert instance.priority == InstancePriority.PRODUCTION
@@ -58,7 +70,11 @@ class TestExplicitPriority:
     def test_staging(self):
         instance = Instance(
             id="test-staging",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             priority=InstancePriority.STAGING,
         )
         assert instance.priority == InstancePriority.STAGING
@@ -66,7 +82,11 @@ class TestExplicitPriority:
     def test_ephemeral(self):
         instance = Instance(
             id="test-ephemeral",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             priority=InstancePriority.EPHEMERAL,
         )
         assert instance.priority == InstancePriority.EPHEMERAL
@@ -74,7 +94,11 @@ class TestExplicitPriority:
     def test_production_explicit(self):
         instance = Instance(
             id="test-prod",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             priority=InstancePriority.PRODUCTION,
         )
         assert instance.priority == InstancePriority.PRODUCTION
@@ -86,7 +110,11 @@ class TestOwnershipFields:
     def test_defaults_are_none(self):
         instance = Instance(
             id="test-own-default",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
         )
         assert instance.managed_by is None
         assert instance.intent_id is None
@@ -94,7 +122,11 @@ class TestOwnershipFields:
     def test_explicit_managed(self):
         instance = Instance(
             id="test-managed",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             managed_by="intent",
             intent_id="abc-123",
         )
@@ -105,7 +137,11 @@ class TestOwnershipFields:
         """managed_by can be set without intent_id (future use)."""
         instance = Instance(
             id="test-managed-only",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             managed_by="intent",
         )
         assert instance.managed_by == "intent"
@@ -119,7 +155,11 @@ class TestPriorityValidation:
         with pytest.raises(ValidationError):
             Instance(
                 id="test-invalid",
-                config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+                config={
+                    "backend_type": "llamacpp",
+                    "model": "/tmp/test.gguf",
+                    "alias": "test",
+                },
                 priority="dev",
             )
 
@@ -130,7 +170,11 @@ class TestSerialization:
     def test_json_serialization(self):
         instance = Instance(
             id="test-serialize",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             priority=InstancePriority.STAGING,
             managed_by="intent",
             intent_id="abc-123",
@@ -144,7 +188,11 @@ class TestSerialization:
         """model_dump(mode='json') → model_validate roundtrips."""
         instance = Instance(
             id="test-roundtrip",
-            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            config={
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test",
+            },
             priority=InstancePriority.EPHEMERAL,
             managed_by="intent",
             intent_id="xyz-789",

--- a/tests/test_instance_priority.py
+++ b/tests/test_instance_priority.py
@@ -1,0 +1,188 @@
+"""Tests for S-036: instance priority, managed_by, and intent_id fields."""
+
+import pytest
+from pydantic import ValidationError
+
+from solar_host.models.base import InstancePriority, Instance, InstanceCreate
+
+
+class TestInstancePriorityEnum:
+    """Tests for the InstancePriority enum."""
+
+    def test_three_values(self):
+        assert len(InstancePriority) == 3
+
+    def test_production(self):
+        assert InstancePriority.PRODUCTION.value == "production"
+
+    def test_staging(self):
+        assert InstancePriority.STAGING.value == "staging"
+
+    def test_ephemeral(self):
+        assert InstancePriority.EPHEMERAL.value == "ephemeral"
+
+
+class TestInstancePriorityDefault:
+    """Default priority for new and migrated instances."""
+
+    def test_default_is_production(self):
+        instance = Instance(
+            id="test-default",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+        )
+        assert instance.priority == InstancePriority.PRODUCTION
+
+    def test_explicit_none_rejected(self):
+        """Explicit None for priority is rejected — use omit for default."""
+        with pytest.raises(ValidationError):
+            Instance(
+                id="test-none",
+                config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+                priority=None,
+            )
+
+    def test_omitted_priority_defaults_to_production(self):
+        """When priority is omitted (not in dict), default is production."""
+        instance = Instance.model_validate(
+            {
+                "id": "test-omitted",
+                "config": {"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            }
+        )
+        assert instance.priority == InstancePriority.PRODUCTION
+
+
+class TestExplicitPriority:
+    """Setting explicit priorities."""
+
+    def test_staging(self):
+        instance = Instance(
+            id="test-staging",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            priority=InstancePriority.STAGING,
+        )
+        assert instance.priority == InstancePriority.STAGING
+
+    def test_ephemeral(self):
+        instance = Instance(
+            id="test-ephemeral",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            priority=InstancePriority.EPHEMERAL,
+        )
+        assert instance.priority == InstancePriority.EPHEMERAL
+
+    def test_production_explicit(self):
+        instance = Instance(
+            id="test-prod",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            priority=InstancePriority.PRODUCTION,
+        )
+        assert instance.priority == InstancePriority.PRODUCTION
+
+
+class TestOwnershipFields:
+    """managed_by and intent_id ownership (S-036 / deployment-intent §5)."""
+
+    def test_defaults_are_none(self):
+        instance = Instance(
+            id="test-own-default",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+        )
+        assert instance.managed_by is None
+        assert instance.intent_id is None
+
+    def test_explicit_managed(self):
+        instance = Instance(
+            id="test-managed",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            managed_by="intent",
+            intent_id="abc-123",
+        )
+        assert instance.managed_by == "intent"
+        assert instance.intent_id == "abc-123"
+
+    def test_managed_by_without_intent_id_allowed(self):
+        """managed_by can be set without intent_id (future use)."""
+        instance = Instance(
+            id="test-managed-only",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            managed_by="intent",
+        )
+        assert instance.managed_by == "intent"
+        assert instance.intent_id is None
+
+
+class TestPriorityValidation:
+    """Invalid priorities are rejected."""
+
+    def test_invalid_priority_rejected(self):
+        with pytest.raises(ValidationError):
+            Instance(
+                id="test-invalid",
+                config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+                priority="dev",
+            )
+
+
+class TestSerialization:
+    """Priority appears in JSON serialization."""
+
+    def test_json_serialization(self):
+        instance = Instance(
+            id="test-serialize",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            priority=InstancePriority.STAGING,
+            managed_by="intent",
+            intent_id="abc-123",
+        )
+        data = instance.model_dump(mode="json")
+        assert data["priority"] == "staging"
+        assert data["managed_by"] == "intent"
+        assert data["intent_id"] == "abc-123"
+
+    def test_json_roundtrip(self):
+        """model_dump(mode='json') → model_validate roundtrips."""
+        instance = Instance(
+            id="test-roundtrip",
+            config={"backend_type": "llamacpp", "model": "/tmp/test.gguf", "alias": "test"},
+            priority=InstancePriority.EPHEMERAL,
+            managed_by="intent",
+            intent_id="xyz-789",
+        )
+        data = instance.model_dump(mode="json")
+        restored = Instance.model_validate(data)
+        assert restored.priority == InstancePriority.EPHEMERAL
+        assert restored.managed_by == "intent"
+        assert restored.intent_id == "xyz-789"
+
+
+class TestInstanceCreate:
+    """InstanceCreate model carries priority/ownership."""
+
+    def test_create_with_priority(self):
+        create = InstanceCreate(
+            config={"backend_type": "llamacpp", "model": "/tmp/t.gguf", "alias": "t"},
+            priority="staging",
+        )
+        assert create.priority == "staging"
+        assert create.managed_by is None
+        assert create.intent_id is None
+
+    def test_create_with_all_fields(self):
+        create = InstanceCreate(
+            config={"backend_type": "llamacpp", "model": "/tmp/t.gguf", "alias": "t"},
+            priority="ephemeral",
+            managed_by="intent",
+            intent_id="int-001",
+        )
+        assert create.priority == "ephemeral"
+        assert create.managed_by == "intent"
+        assert create.intent_id == "int-001"
+
+    def test_create_without_priority_defaults_none(self):
+        create = InstanceCreate(
+            config={"backend_type": "llamacpp", "model": "/tmp/t.gguf", "alias": "t"},
+        )
+        assert create.priority is None
+        assert create.managed_by is None
+        assert create.intent_id is None


### PR DESCRIPTION
## Description

Add a `priority` field to inference instances with three levels (`production`, `staging`, `ephemeral`), plus `managed_by` and `intent_id` ownership fields for declarative-intent reconciliation. Priority defaults to `production` and is persisted in config.json, validated on create, and included in all host→control payloads.

## Changes

- Add `InstancePriority` enum with `production`, `staging`, `ephemeral` values
- Add `priority`, `managed_by`, `intent_id` fields to `Instance` and `InstanceCreate` models
- Validate priority in POST `/instances` route (invalid → 422)
- Default to `production` in `process_manager.create_instance()`
- Include priority/ownership in `send_instances_update()` and `_send_registration()` payloads to solar-control
- 19 unit tests covering enum, defaults, validation, serialization, and ownership

## Related Issue
DamitDev/solar-control/issues/37 closed by merging https://github.com/DamitDev/solar-control/pull/50