### PR TITLE
feat(llamacpp): add Draft MTP speculative decoding launch flags

### DIFF
--- a/solar_host/backends/llamacpp.py
+++ b/solar_host/backends/llamacpp.py
@@ -90,6 +90,22 @@ class LlamaCppRunner(BackendRunner):
         if reasoning_budget is not None:
             cmd.extend(["--reasoning-budget", str(int(reasoning_budget))])
 
+        spec_type = getattr(config, "spec_type", None)
+        spec_draft_n_max = getattr(config, "spec_draft_n_max", None)
+        if (
+            getattr(config, "model_type", "llm") == "llm"
+            and spec_type == "draft-mtp"
+            and spec_draft_n_max is not None
+        ):
+            cmd.extend(
+                [
+                    "--spec-type",
+                    spec_type,
+                    "--spec-draft-n-max",
+                    str(int(spec_draft_n_max)),
+                ]
+            )
+
         cache_type_k = getattr(config, "cache_type_k", None)
         if cache_type_k and cache_type_k.strip():
             cmd.extend(["-ctk", cache_type_k.strip()])

--- a/solar_host/models/llamacpp.py
+++ b/solar_host/models/llamacpp.py
@@ -69,6 +69,15 @@ class LlamaCppConfig(BaseModel):
         default=None,
         description="Reasoning budget token limit (passed as --reasoning-budget to llama-server)",
     )
+    spec_type: Optional[Literal["draft-mtp"]] = Field(
+        default=None,
+        description="Speculative decoding type (passed as --spec-type to llama-server)",
+    )
+    spec_draft_n_max: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Maximum speculative draft tokens (passed as --spec-draft-n-max to llama-server)",
+    )
     cache_type_k: Optional[
         Literal["f32", "f16", "bf16", "q8_0", "q4_0", "q4_1", "iq4_nl", "q5_0", "q5_1"]
     ] = Field(default=None, description="KV cache quantization type for keys (-ctk)")

--- a/tests/test_llamacpp_command.py
+++ b/tests/test_llamacpp_command.py
@@ -1,0 +1,38 @@
+"""Tests for llama.cpp command construction."""
+
+from types import SimpleNamespace
+
+from solar_host.backends.llamacpp import LlamaCppRunner
+from solar_host.models.llamacpp import LlamaCppConfig
+
+
+def build_command(**config_overrides: object) -> list[str]:
+    config = LlamaCppConfig(model="/models/test.gguf", alias="test", **config_overrides)
+    instance = SimpleNamespace(config=config, port=8080)
+    return LlamaCppRunner().build_command(instance)
+
+
+def test_speculative_decoding_flags_are_omitted_by_default() -> None:
+    command = build_command()
+
+    assert "--spec-type" not in command
+    assert "--spec-draft-n-max" not in command
+
+
+def test_draft_mtp_speculative_decoding_flags_are_added_together() -> None:
+    command = build_command(spec_type="draft-mtp", spec_draft_n_max=2)
+
+    spec_type_index = command.index("--spec-type")
+    assert command[spec_type_index : spec_type_index + 4] == [
+        "--spec-type",
+        "draft-mtp",
+        "--spec-draft-n-max",
+        "2",
+    ]
+
+
+def test_speculative_decoding_flags_are_ignored_for_non_generation_models() -> None:
+    command = build_command(model_type="embedding", spec_type="draft-mtp", spec_draft_n_max=2)
+
+    assert "--spec-type" not in command
+    assert "--spec-draft-n-max" not in command

--- a/tests/test_llamacpp_command.py
+++ b/tests/test_llamacpp_command.py
@@ -32,7 +32,9 @@ def test_draft_mtp_speculative_decoding_flags_are_added_together() -> None:
 
 
 def test_speculative_decoding_flags_are_ignored_for_non_generation_models() -> None:
-    command = build_command(model_type="embedding", spec_type="draft-mtp", spec_draft_n_max=2)
+    command = build_command(
+        model_type="embedding", spec_type="draft-mtp", spec_draft_n_max=2
+    )
 
     assert "--spec-type" not in command
     assert "--spec-draft-n-max" not in command


### PR DESCRIPTION
## Summary
- Add optional `spec_type` and `spec_draft_n_max` fields to `LlamaCppConfig`
- Update `LlamaCppRunner.build_command()` to emit `--spec-type draft-mtp --spec-draft-n-max <n>` only for LLM instances when both values are set
- Leave launch params unchanged by default when speculative decoding is not configured

## Test plan
- [ ] Run `uv run --extra dev pytest tests/test_llamacpp_command.py -v`
- [ ] Verify default llama.cpp config does not include `--spec-type` or `--spec-draft-n-max`
- [ ] Start an LLM instance with `spec_type: "draft-mtp"` and `spec_draft_n_max: 2` and confirm both flags appear in the launch command
- [ ] Confirm embedding/reranker instances ignore speculative decoding config even if present
- [ ] Deploy with matching solar-webui changes and verify end-to-end instance creation from the UI