### PR TITLE
fix(api): preserve model_source URI for cross-host operations

### DIFF
--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -165,7 +165,11 @@ def parse_instance_config(config_data: Dict[str, Any]) -> Any:
     # before proxying; skip resolution in that case to avoid redundant validation
     # and preserve the original model_source URI for cross-host operations).
     model_source = config_data.get("model_source")
-    if model_source and not config_data.get("model") and not config_data.get("model_id"):
+    if (
+        model_source
+        and not config_data.get("model")
+        and not config_data.get("model_id")
+    ):
         resolved_path = resolve_model_source(model_source)
         if backend_type == "llamacpp":
             config_data["model"] = resolved_path

--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -160,9 +160,12 @@ def parse_instance_config(config_data: Dict[str, Any]) -> Any:
 
     backend_type = config_data.get("backend_type", "llamacpp")
 
-    # Resolve model_source if present
+    # Resolve model_source if present, but only when no explicit model/model_id
+    # was provided (solar-control resolves model_source and sets model/model_id
+    # before proxying; skip resolution in that case to avoid redundant validation
+    # and preserve the original model_source URI for cross-host operations).
     model_source = config_data.get("model_source")
-    if model_source:
+    if model_source and not config_data.get("model") and not config_data.get("model_id"):
         resolved_path = resolve_model_source(model_source)
         if backend_type == "llamacpp":
             config_data["model"] = resolved_path


### PR DESCRIPTION
## Description

When solar-control resolves a `model_source` URI (repo://, huggingface://) before
creating an instance, it was overwriting the original URI with the resolved
local:// path. This lost the authoritative source reference, breaking cross-host
operations like S-037 migration that need the original URI to pull the model on
another host.

This PR fixes the resolution flow across both repos: solar-control now sets the
derived model/model_id from the resolved path while preserving the original
model_source, and solar-host skips redundant re-resolution when the field is
already populated.

## Changes

### solar-host (`solar_host/config.py`)
- `parse_instance_config`: skip model_source resolution when `model` or `model_id`
  is already present in the config dict
- Original `model_source` URI (repo://, huggingface://) is retained unmodified

## Related Issues

Required by S-037 (instance migration) which captures instance config and needs
the original model_source to pull the model on the target host.
