### PR TITLE
feat(ws): include model_source in instance WS notifications

### DIFF
--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -284,6 +284,7 @@ class SolarControlClient:
                     ),
                     "managed_by": instance.managed_by,
                     "intent_id": instance.intent_id,
+                    "model_source": getattr(instance.config, "model_source", None),
                 }
             )
 
@@ -437,6 +438,7 @@ class SolarControlClient:
                     ),
                     "managed_by": instance.managed_by,
                     "intent_id": instance.intent_id,
+                    "model_source": getattr(instance.config, "model_source", None),
                 }
             )
 


### PR DESCRIPTION
## Description

Includes `model_source` in the WebSocket instance payloads so Solar Control sees the original model source URI (repo://, huggingface://, local://) in real-time — not just the resolved local path. This is needed for S-037 migration, which captures the complete instance config on the source host to recreate the instance on a target host.

Builds on PR #62, which preserved the original `model_source` URI during resolution. Without this change, Solar Control's WS-driven state would lack the source reference for instances created after connection, forcing callers to fetch it separately from the REST API.

## Changes

### `solar_host/ws_client.py`
- Added `model_source: getattr(instance.config, "model_source", None)` to the `instances_update` WebSocket event payload
- Added `model_source` to the `registration` WebSocket event payload (initial sync on connect)

## Related Issues

Required by S-037 (instance migration) and builds on PR #62 (preserve model_source URI)
