### PR TITLE
feat(models): support repo:// subpath URIs in pull and slug derivation (D-017)

### DIFF
--- a/solar_host/models/base.py
+++ b/solar_host/models/base.py
@@ -164,12 +164,16 @@ class InstanceCreate(BaseModel):
 
 
 class InstanceUpdate(BaseModel):
-    """Request to update an instance config.
+    """Request to update an instance config or ownership markers.
 
     Note: config field uses Any type here to avoid circular imports.
+    All fields are optional; only explicitly-provided fields are applied
+    (``managed_by``/``intent_id`` may be set to null to clear ownership).
     """
 
-    config: Any  # InstanceConfig
+    config: Optional[Any] = None  # InstanceConfig
+    managed_by: Optional[str] = None
+    intent_id: Optional[str] = None
 
 
 class InstanceResponse(BaseModel):

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -29,7 +29,7 @@ from solar_host.memory_monitor import get_disk_info
 
 logger = logging.getLogger(__name__)
 
-_REPO_PATTERN = re.compile(r"^repo://([A-Za-z0-9\-_]+):([A-Za-z0-9\-_.]+)$")
+_REPO_PATTERN = re.compile(r"^repo://([A-Za-z0-9\-_]+):([A-Za-z0-9\-_.]+)(/.*)?$")
 _HF_PATTERN = re.compile(r"^huggingface://(.+)$")
 
 MANIFEST_FILENAME = "manifest.json"
@@ -81,6 +81,10 @@ def ensure_models_dir() -> None:
 def source_uri_to_slug(uri: str) -> str:
     """Derive a deterministic directory slug from a model source URI.
 
+    For ``repo://name:version/subpath`` the subpath is ignored — the slug
+    is always ``repo--name--version`` (the subpath selects a file inside
+    the pulled artifact directory).
+
     Raises ValueError for local:// URIs (not stored in MODELS_DIR)
     and for unrecognised or malformed URIs.
     """
@@ -98,6 +102,35 @@ def source_uri_to_slug(uri: str) -> str:
         return f"hf--{model_id.replace('/', '--')}"
 
     raise ValueError(f"Unsupported or malformed model source URI: {uri}")
+
+
+def extract_repo_subpath(uri: str) -> str:
+    """Return the subpath of a ``repo://name:version/subpath`` URI.
+
+    Returns the subpath without the leading slash (e.g. ``model.gguf``
+    for ``repo://iris-osl:v3/model.gguf``), or ``""`` when the URI has
+    no subpath or is not a ``repo://`` URI.
+    """
+    if not uri.startswith("repo://"):
+        return ""
+    m = _REPO_PATTERN.match(uri)
+    if m and m.group(3):
+        return m.group(3).lstrip("/")
+    return ""
+
+
+def repo_base_uri(uri: str) -> str:
+    """Strip the subpath from a ``repo://name:version/subpath`` URI.
+
+    Returns ``repo://name:version`` (the artifact identity used as the
+    manifest cache key).  Non-repo URIs are returned unchanged.
+    """
+    if not uri.startswith("repo://"):
+        return uri
+    m = _REPO_PATTERN.match(uri)
+    if m:
+        return f"repo://{m.group(1)}:{m.group(2)}"
+    return uri
 
 
 def _manifest_path() -> Path:
@@ -344,28 +377,36 @@ def pull_model(
             source_uri,
         )
 
-    # Acquire a per-URI lock so that concurrent pulls for the *same* source_uri
-    # are serialised end-to-end.  The second caller will block here, then see
-    # the cache hit once the first caller finishes.
-    uri_lock = _get_uri_lock(source_uri)
+    # Acquire a per-URI lock so that concurrent pulls for the *same* artifact
+    # are serialised end-to-end.  The lock key is the base URI (subpath
+    # stripped) — different subpaths of one artifact share the directory.
+    uri_lock = _get_uri_lock(repo_base_uri(source_uri))
     with uri_lock:
-        # 2. Cache check — manifest is the single source of truth.
-        #    Verify the files still exist on disk; remove stale entries.
-        cached_entry = get_manifest_entry(source_uri)
+        # 2a. Extract optional subpath (repo://name:version/subpath → file
+        #     inside the artifact directory).  The slug stays name:version.
+        subpath = extract_repo_subpath(source_uri)
+        cache_key = repo_base_uri(source_uri)
+
+        # 2. Cache check — manifest is the single source of truth, keyed by
+        #    the base URI (the artifact identity).  Verify the resolved path
+        #    (dir + optional subpath) still exists on disk.
+        cached_entry = get_manifest_entry(cache_key)
         if cached_entry is not None:
-            if Path(cached_entry.path).exists():
+            cached_path = Path(cached_entry.path)
+            resolved_cache = cached_path / subpath if subpath else cached_path
+            if resolved_cache.exists():
                 return {
-                    "path": cached_entry.path,
+                    "path": str(resolved_cache),
                     "cached": True,
                     "source_uri": source_uri,
                 }
             logger.warning(
                 "Manifest entry for %s points to missing path %s, re-pulling",
-                source_uri,
+                cache_key,
                 cached_entry.path,
             )
             with _manifest_lock:
-                remove_manifest_entry(source_uri)
+                remove_manifest_entry(cache_key)
 
         # 3. Derive slug and target directory.
         try:
@@ -476,11 +517,30 @@ def pull_model(
         # 7. Compute size of downloaded files.
         size_bytes = _compute_dir_size(target_dir)
 
+        # 7.5 Resolve the returned path.  When the URI carries a subpath
+        #     (repo://name:version/model.gguf), the returned path points at
+        #     that file inside the pulled directory.  A subpath that does
+        #     not exist in the artifact is a client error (404).
+        if subpath:
+            resolved_path = target_dir / subpath
+            if not resolved_path.exists():
+                shutil.rmtree(target_dir, ignore_errors=True)
+                raise ModelPullError(
+                    404,
+                    "not_found",
+                    f"Subpath '{subpath}' not found in artifact for {source_uri}.",
+                    source_uri,
+                )
+        else:
+            resolved_path = target_dir
+
         # 8. Update manifest atomically under lock to prevent concurrent write
         #    races between pulls for *different* URIs finishing simultaneously.
+        #    The entry is keyed by the base URI (artifact identity), so any
+        #    subpath of the same artifact resolves against the same entry.
         entry = ManifestEntry(
             slug=slug,
-            source_uri=source_uri,
+            source_uri=cache_key,
             path=str(target_dir.resolve()),
             size_bytes=size_bytes,
             digest=digest,
@@ -494,9 +554,9 @@ def pull_model(
         with _manifest_lock:
             add_manifest_entry(entry)
 
-        logger.info("Model pulled successfully: %s -> %s", source_uri, target_dir)
+        logger.info("Model pulled successfully: %s -> %s", source_uri, resolved_path)
         return {
-            "path": str(target_dir.resolve()),
+            "path": str(resolved_path.resolve()),
             "cached": False,
             "source_uri": source_uri,
         }

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -85,6 +85,13 @@ async def update_instance(instance_id: str, data: InstanceUpdate):
         if "intent_id" in data.model_fields_set:
             instance.intent_id = data.intent_id
         config_manager.update_instance(instance_id, instance)
+        # Push the updated instance list so solar-control's Redis cache
+        # reflects the authoritative post-update state. Without this, a
+        # stale instances_update (e.g. the stop event emitted before a
+        # disown) can re-populate ownership markers after the disown and
+        # the intent reconciler will fight the instance again (surplus
+        # STOP deletes it). (D-017)
+        process_manager._push_instances_update()
         return InstanceResponse(
             instance=instance, message=f"Instance {instance_id} updated successfully"
         )

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -71,12 +71,19 @@ async def update_instance(instance_id: str, data: InstanceUpdate):
         )
 
     try:
-        # Parse config if it's a dict (from FastAPI request body)
-        config = data.config
-        if isinstance(config, dict):
-            config = parse_instance_config(config)
-
-        instance.config = config
+        # Parse config if it's a dict (from FastAPI request body).
+        # Only apply fields explicitly present in the payload, so a
+        # config-only update never clobbers ownership markers and a
+        # marker-clearing update can set them to null (S-037 disown).
+        if data.config is not None:
+            config = data.config
+            if isinstance(config, dict):
+                config = parse_instance_config(config)
+            instance.config = config
+        if "managed_by" in data.model_fields_set:
+            instance.managed_by = data.managed_by
+        if "intent_id" in data.model_fields_set:
+            instance.intent_id = data.intent_id
         config_manager.update_instance(instance_id, instance)
         return InstanceResponse(
             instance=instance, message=f"Instance {instance_id} updated successfully"

--- a/tests/test_instance_priority.py
+++ b/tests/test_instance_priority.py
@@ -3,7 +3,12 @@
 import pytest
 from pydantic import ValidationError
 
-from solar_host.models.base import InstancePriority, Instance, InstanceCreate
+from solar_host.models.base import (
+    InstancePriority,
+    Instance,
+    InstanceCreate,
+    InstanceUpdate,
+)
 
 
 class TestInstancePriorityEnum:
@@ -234,3 +239,33 @@ class TestInstanceCreate:
         assert create.priority is None
         assert create.managed_by is None
         assert create.intent_id is None
+
+
+class TestInstanceUpdate:
+    """InstanceUpdate carries optional ownership-marker fields (D-017 disown)."""
+
+    def test_config_only_update(self):
+        update = InstanceUpdate(
+            config={"backend_type": "llamacpp", "model": "/tmp/t.gguf", "alias": "t"},
+        )
+        assert update.config is not None
+        # Not in model_fields_set → markers untouched by the route.
+        assert "managed_by" not in update.model_fields_set
+        assert "intent_id" not in update.model_fields_set
+
+    def test_marker_clearing_update(self):
+        update = InstanceUpdate(
+            config={"backend_type": "llamacpp", "model": "/tmp/t.gguf", "alias": "t"},
+            managed_by=None,
+            intent_id=None,
+        )
+        assert "managed_by" in update.model_fields_set
+        assert "intent_id" in update.model_fields_set
+        assert update.managed_by is None
+        assert update.intent_id is None
+
+    def test_config_optional_for_marker_update(self):
+        update = InstanceUpdate(managed_by=None, intent_id=None)
+        assert update.config is None
+        assert "managed_by" in update.model_fields_set
+        assert "intent_id" in update.model_fields_set

--- a/tests/test_models_manager.py
+++ b/tests/test_models_manager.py
@@ -12,6 +12,7 @@ from solar_host.models_manager import (
     ManifestEntry,
     add_manifest_entry,
     ensure_models_dir,
+    extract_repo_subpath,
     get_manifest_entry,
     get_models_dir,
     read_manifest,
@@ -58,10 +59,31 @@ class TestSourceUriToSlug:
             ("repo://iris-osl:v3", "repo--iris-osl--v3"),
             ("repo://iris-tickets:2026-03", "repo--iris-tickets--2026-03"),
             ("repo://IRIS-BERT-base:v1", "repo--IRIS-BERT-base--v1"),
+            # Subpath variant: slug ignores the file path inside the artifact
+            (
+                "repo://iris-osl:v3/model.gguf",
+                "repo--iris-osl--v3",
+            ),
+            (
+                "repo://iris-osl:v3/subdir/model.gguf",
+                "repo--iris-osl--v3",
+            ),
         ],
     )
     def test_repo_scheme(self, uri: str, expected: str):
         assert source_uri_to_slug(uri) == expected
+
+    @pytest.mark.parametrize(
+        "uri, expected",
+        [
+            ("repo://iris-osl:v3", ""),
+            ("repo://iris-osl:v3/model.gguf", "model.gguf"),
+            ("repo://iris-osl:v3/subdir/model.gguf", "subdir/model.gguf"),
+            ("huggingface://microsoft/phi-3", ""),
+        ],
+    )
+    def test_extract_repo_subpath(self, uri: str, expected: str):
+        assert extract_repo_subpath(uri) == expected
 
     @pytest.mark.parametrize(
         "uri, expected",

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -273,6 +273,58 @@ class TestCacheHit:
         assert resp.json()["cached"] is True
         mock_dl.assert_not_called()
 
+    def test_cache_hit_with_subpath_returns_file_path(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Cache hit for repo://name:version/model.gguf returns dir/model.gguf."""
+        ensure_models_dir()
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        (slug_dir / "model.gguf").write_bytes(b"x")
+        add_manifest_entry(_make_manifest_entry(path=str(slug_dir.resolve())))
+
+        body = _harbor_body(source_uri="repo://iris-osl:v3/model.gguf")
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is True
+        assert data["path"] == str((slug_dir / "model.gguf").resolve())
+        mock_pull.assert_not_called()
+
+    def test_cache_hit_with_subpath_missing_file_re_pulls(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Cache entry exists but the subpath file is gone → re-pull."""
+        ensure_models_dir()
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        (slug_dir / "model.gguf").write_bytes(b"x")
+        add_manifest_entry(_make_manifest_entry(path=str(slug_dir.resolve())))
+
+        body = _harbor_body(source_uri="repo://iris-osl:v3/other.gguf")
+
+        def _side_effect(harbor_ref: str, target_dir: Path, source_uri: str):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            # Re-create the file named by the subpath in source_uri
+            from solar_host.models_manager import extract_repo_subpath
+
+            fname = extract_repo_subpath(source_uri)
+            (target_dir / fname).write_bytes(b"x" * 1024)
+
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=_side_effect,
+        ) as mock_pull:
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is False
+        assert data["path"] == str((slug_dir / "other.gguf").resolve())
+        mock_pull.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Harbor pull (cache miss)
@@ -334,6 +386,44 @@ class TestHarborPull:
 
         assert captured["harbor_ref"] == "imgrepo.damit.hu/supernova/iris-osl:v3"
         assert str(captured["target_dir"]).endswith("repo--iris-osl--v3")
+
+    def test_harbor_pull_with_subpath_returns_file_path(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Fresh pull for repo://name:version/model.gguf returns dir/model.gguf."""
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ) as mock_pull:
+            body = _harbor_body(source_uri="repo://iris-osl:v3/model.gguf")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is False
+        assert data["path"].endswith("repo--iris-osl--v3/model.gguf")
+        mock_pull.assert_called_once()
+
+    def test_harbor_pull_with_missing_subpath_returns_404(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Subpath not present in the artifact → 404 and directory cleaned up."""
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._make_mock_pull(_isolated_env),
+        ):
+            body = _harbor_body(source_uri="repo://iris-osl:v3/nonexistent.gguf")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["error"] == "not_found"
+        assert "nonexistent.gguf" in data["detail"]
+
+        # The stale directory must have been removed; manifest must be empty.
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        assert not slug_dir.exists()
+        assert get_manifest_entry("repo://iris-osl:v3/nonexistent.gguf") is None
 
     def test_second_pull_returns_cached(self, client: TestClient, _isolated_env: Path):
         """After a successful pull, the same URI returns cached=True."""

--- a/tests/test_routes_instances_update.py
+++ b/tests/test_routes_instances_update.py
@@ -1,0 +1,93 @@
+"""Tests for PUT /instances/{id} ownership-marker updates (D-017 disown)."""
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from solar_host.main import app
+
+API_KEY = "test-disown-key"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path: Path, monkeypatch):
+    """Fresh config dir, no WS clients, fixed API key."""
+    monkeypatch.setattr(
+        "solar_host.config.settings.config_file", str(tmp_path / "config.json")
+    )
+    monkeypatch.setattr("solar_host.config.settings.solar_control_url", "")
+    monkeypatch.setattr("solar_host.config.settings.api_key", API_KEY)
+
+
+@pytest.fixture()
+def client():
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def _headers() -> dict:
+    return {"X-API-Key": API_KEY}
+
+
+def _create_instance(client: TestClient, *, managed_by: str = "intent") -> str:
+    resp = client.post(
+        "/instances",
+        headers=_headers(),
+        json={
+            "config": {
+                "backend_type": "llamacpp",
+                "model": "/tmp/test.gguf",
+                "alias": "test-disown",
+                "model_source": "repo://test-disown:v1",
+            },
+            "managed_by": managed_by,
+            "intent_id": "intent-123",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["instance"]["id"]
+
+
+class TestDisownUpdate:
+    def test_marker_clearing_update(self, client: TestClient):
+        """PUT with managed_by/intent_id null clears ownership markers."""
+        instance_id = _create_instance(client)
+        inst = client.get(f"/instances/{instance_id}", headers=_headers()).json()
+        assert inst["managed_by"] == "intent"
+        assert inst["intent_id"] == "intent-123"
+
+        resp = client.put(
+            f"/instances/{instance_id}",
+            headers=_headers(),
+            json={"managed_by": None, "intent_id": None},
+        )
+        assert resp.status_code == 200, resp.text
+
+        inst = client.get(f"/instances/{instance_id}", headers=_headers()).json()
+        assert inst["managed_by"] is None
+        assert inst["intent_id"] is None
+
+    def test_config_only_update_preserves_markers(self, client: TestClient):
+        """A config-only PUT must not clobber ownership markers."""
+        instance_id = _create_instance(client)
+
+        resp = client.put(
+            f"/instances/{instance_id}",
+            headers=_headers(),
+            json={
+                "config": {
+                    "backend_type": "llamacpp",
+                    "model": "/tmp/test.gguf",
+                    "alias": "test-disown",
+                    "model_source": "repo://test-disown:v1",
+                    "threads": 8,
+                }
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        inst = client.get(f"/instances/{instance_id}", headers=_headers()).json()
+        assert inst["managed_by"] == "intent"
+        assert inst["intent_id"] == "intent-123"
+        assert inst["config"]["threads"] == 8

--- a/tests/test_routes_instances_update.py
+++ b/tests/test_routes_instances_update.py
@@ -91,3 +91,30 @@ class TestDisownUpdate:
         assert inst["managed_by"] == "intent"
         assert inst["intent_id"] == "intent-123"
         assert inst["config"]["threads"] == 8
+
+    def test_update_pushes_instances_update(self, client: TestClient, monkeypatch):
+        """A marker/config update must push instances_update to solar-control.
+
+        Regression (D-017): without the push, a stale instances_update
+        (e.g. the stop event emitted before a disown) can re-populate
+        ownership markers in solar-control's Redis cache after the disown,
+        and the intent reconciler then sees a surplus managed instance and
+        deletes the disowned source.
+        """
+        import solar_host.process_manager as pm
+
+        instance_id = _create_instance(client)
+        pushed = []
+        monkeypatch.setattr(
+            pm.ProcessManager,
+            "_push_instances_update",
+            lambda self: pushed.append(True),
+        )
+
+        resp = client.put(
+            f"/instances/{instance_id}",
+            headers=_headers(),
+            json={"managed_by": None, "intent_id": None},
+        )
+        assert resp.status_code == 200, resp.text
+        assert len(pushed) == 1, "instances_update must be pushed after update"


### PR DESCRIPTION
## Description
Support `repo://` URIs with an optional subpath (e.g. `repo://iris-osl:v3/model.gguf`) on Solar Host. The subpath selects a specific file inside the pulled artifact directory — needed for GGUF models, where llama.cpp requires the exact `.gguf` file path rather than the artifact directory.

## Changes
- `_REPO_PATTERN` now accepts an optional trailing subpath (`repo://name:version/subpath`)
- `source_uri_to_slug()` ignores the subpath — slug remains `repo--name--version`
- Added `extract_repo_subpath()` and `repo_base_uri()` helpers
- `pull_model()` returns `<dir>/<subpath>` when the URI carries one; cache lookup and manifest entries are keyed by the base URI (artifact identity)
- Subpath missing from the pulled artifact returns 404 with cleanup
- Tests: slug derivation, subpath extraction, cache-hit with subpath, fresh pull with subpath, missing subpath → 404

## Related Issues
D-017
