### PR TITLE
fix(ws): post-approval registration sync + pull digest verification (D-017)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ logs/
 .env
 .env.local
 
+
+# Test suite runtime artifact
+models/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,8 @@ packages = ["solar_host"]
 target-version = ["py312"]
 line-length = 88
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = [
+    "fastapi.Depends",
+]
+

--- a/solar_host/__init__.py
+++ b/solar_host/__init__.py
@@ -1,6 +1,6 @@
 """Solar Host - Process manager for model inference backends."""
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("solar-host")

--- a/solar_host/backends/__init__.py
+++ b/solar_host/backends/__init__.py
@@ -1,12 +1,12 @@
 """Backend runners package for solar-host."""
 
 from solar_host.backends.base import BackendRunner, RuntimeStateUpdate
-from solar_host.backends.llamacpp import LlamaCppRunner
 from solar_host.backends.huggingface import HuggingFaceRunner
+from solar_host.backends.llamacpp import LlamaCppRunner
 
 __all__ = [
     "BackendRunner",
-    "RuntimeStateUpdate",
-    "LlamaCppRunner",
     "HuggingFaceRunner",
+    "LlamaCppRunner",
+    "RuntimeStateUpdate",
 ]

--- a/solar_host/backends/base.py
+++ b/solar_host/backends/base.py
@@ -1,8 +1,8 @@
 """Abstract base class for backend runners."""
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Any, Dict
 from dataclasses import dataclass
+from typing import Any
 
 from solar_host.models.base import InstancePhase
 
@@ -13,16 +13,16 @@ class RuntimeStateUpdate:
 
     busy: bool
     phase: InstancePhase
-    prefill_progress: Optional[float] = None
+    prefill_progress: float | None = None
     active_slots: int = 0
-    slot_id: Optional[int] = None
-    task_id: Optional[int] = None
-    prefill_prompt_tokens: Optional[int] = None
-    generated_tokens: Optional[int] = None
-    decode_tps: Optional[float] = None
-    decode_ms_per_token: Optional[float] = None
-    checkpoint_index: Optional[int] = None
-    checkpoint_total: Optional[int] = None
+    slot_id: int | None = None
+    task_id: int | None = None
+    prefill_prompt_tokens: int | None = None
+    generated_tokens: int | None = None
+    decode_tps: float | None = None
+    decode_ms_per_token: float | None = None
+    checkpoint_index: int | None = None
+    checkpoint_total: int | None = None
 
 
 class BackendRunner(ABC):
@@ -33,7 +33,7 @@ class BackendRunner(ABC):
     """
 
     @abstractmethod
-    def build_command(self, instance: Any) -> List[str]:
+    def build_command(self, instance: Any) -> list[str]:
         """Build the command to start the backend process.
 
         Args:
@@ -42,12 +42,11 @@ class BackendRunner(ABC):
         Returns:
             List of command arguments to spawn the process.
         """
-        pass
 
     @abstractmethod
     def parse_log_line(
-        self, instance_id: str, line: str, context: Dict[str, Any]
-    ) -> Optional[RuntimeStateUpdate]:
+        self, instance_id: str, line: str, context: dict[str, Any]
+    ) -> RuntimeStateUpdate | None:
         """Parse a log line and optionally return a runtime state update.
 
         Args:
@@ -59,7 +58,6 @@ class BackendRunner(ABC):
         Returns:
             RuntimeStateUpdate if the log line indicates a state change, None otherwise.
         """
-        pass
 
     @abstractmethod
     def get_health_endpoint(self) -> str:
@@ -68,16 +66,14 @@ class BackendRunner(ABC):
         Returns:
             The health endpoint path (e.g., "/health").
         """
-        pass
 
     @abstractmethod
-    def get_supported_endpoints(self) -> List[str]:
+    def get_supported_endpoints(self) -> list[str]:
         """Get the list of API endpoints this backend supports.
 
         Returns:
             List of endpoint paths (e.g., ["/v1/chat/completions", "/v1/completions"]).
         """
-        pass
 
     @abstractmethod
     def get_backend_type(self) -> str:
@@ -86,9 +82,8 @@ class BackendRunner(ABC):
         Returns:
             The backend type string (e.g., "llamacpp", "huggingface_causal").
         """
-        pass
 
-    def initialize_context(self) -> Dict[str, Any]:
+    def initialize_context(self) -> dict[str, Any]:
         """Initialize the parsing context for a new instance.
 
         Override this method to provide backend-specific context initialization.
@@ -98,7 +93,7 @@ class BackendRunner(ABC):
         """
         return {}
 
-    def on_process_started(self, instance_id: str, context: Dict[str, Any]) -> None:
+    def on_process_started(self, instance_id: str, context: dict[str, Any]) -> None:
         """Called when the backend process has started.
 
         Override this method to perform post-start initialization.
@@ -107,9 +102,8 @@ class BackendRunner(ABC):
             instance_id: The instance ID.
             context: The instance's parsing context.
         """
-        pass
 
-    def on_process_stopped(self, instance_id: str, context: Dict[str, Any]) -> None:
+    def on_process_stopped(self, instance_id: str, context: dict[str, Any]) -> None:
         """Called when the backend process has stopped.
 
         Override this method to perform cleanup.
@@ -118,9 +112,8 @@ class BackendRunner(ABC):
             instance_id: The instance ID.
             context: The instance's parsing context.
         """
-        pass
 
-    def get_supported_endpoints_for_type(self, backend_type: str) -> List[str]:
+    def get_supported_endpoints_for_type(self, backend_type: str) -> list[str]:
         """Get supported endpoints based on specific backend type.
 
         Override this method if the backend supports multiple model types
@@ -134,7 +127,7 @@ class BackendRunner(ABC):
         """
         return self.get_supported_endpoints()
 
-    def get_last_generation(self, context: Dict[str, Any]) -> Optional[Any]:
+    def get_last_generation(self, context: dict[str, Any]) -> Any | None:
         """Get the last generation metrics from context.
 
         Override this method to provide generation metrics tracking.

--- a/solar_host/backends/huggingface.py
+++ b/solar_host/backends/huggingface.py
@@ -2,11 +2,11 @@
 
 import re
 import sys
-from typing import List, Optional, Any, Dict
+from typing import Any
 
 from solar_host.backends.base import BackendRunner, RuntimeStateUpdate
-from solar_host.models.base import InstancePhase, GenerationMetrics, BackendType
 from solar_host.config import settings
+from solar_host.models.base import BackendType, GenerationMetrics, InstancePhase
 
 
 class HuggingFaceRunner(BackendRunner):
@@ -41,7 +41,7 @@ class HuggingFaceRunner(BackendRunner):
                 "Install with: pip install solar-host[huggingface]"
             )
 
-    def build_command(self, instance: Any) -> List[str]:
+    def build_command(self, instance: Any) -> list[str]:
         """Build command to start HuggingFace server process."""
         self.check_dependencies()
         config = instance.config
@@ -114,7 +114,7 @@ class HuggingFaceRunner(BackendRunner):
     def get_health_endpoint(self) -> str:
         return "/health"
 
-    def get_supported_endpoints(self) -> List[str]:
+    def get_supported_endpoints(self) -> list[str]:
         """Get supported endpoints.
 
         Note: This returns all possible endpoints. The actual endpoints
@@ -127,7 +127,7 @@ class HuggingFaceRunner(BackendRunner):
             "/health",
         ]
 
-    def get_supported_endpoints_for_type(self, backend_type: str) -> List[str]:
+    def get_supported_endpoints_for_type(self, backend_type: str) -> list[str]:
         """Get supported endpoints based on backend type."""
         if (
             backend_type == BackendType.HUGGINGFACE_CAUSAL
@@ -168,7 +168,7 @@ class HuggingFaceRunner(BackendRunner):
             ]
         return ["/v1/models", "/health"]
 
-    def initialize_context(self) -> Dict[str, Any]:
+    def initialize_context(self) -> dict[str, Any]:
         """Initialize parsing context for HuggingFace server log parsing."""
         return {
             "ready": False,
@@ -182,8 +182,8 @@ class HuggingFaceRunner(BackendRunner):
         }
 
     def parse_log_line(
-        self, instance_id: str, line: str, context: Dict[str, Any]
-    ) -> Optional[RuntimeStateUpdate]:
+        self, instance_id: str, line: str, context: dict[str, Any]
+    ) -> RuntimeStateUpdate | None:
         """Parse HuggingFace server log line and return state update if changed."""
         last_state = context.get("last_state", {})
 
@@ -267,11 +267,11 @@ class HuggingFaceRunner(BackendRunner):
         self,
         busy: bool,
         phase: InstancePhase,
-        last_state: Dict[str, Any],
-        context: Dict[str, Any],
-        generated_tokens: Optional[int] = None,
-        decode_tps: Optional[float] = None,
-    ) -> Optional[RuntimeStateUpdate]:
+        last_state: dict[str, Any],
+        context: dict[str, Any],
+        generated_tokens: int | None = None,
+        decode_tps: float | None = None,
+    ) -> RuntimeStateUpdate | None:
         """Create a RuntimeStateUpdate if state has changed."""
         changed = (
             last_state.get("busy") != busy
@@ -298,9 +298,7 @@ class HuggingFaceRunner(BackendRunner):
             decode_tps=decode_tps,
         )
 
-    def get_last_generation(
-        self, context: Dict[str, Any]
-    ) -> Optional[GenerationMetrics]:
+    def get_last_generation(self, context: dict[str, Any]) -> GenerationMetrics | None:
         """Get the last generation metrics from context."""
         recent = context.get("recent_generations", [])
         if not recent:

--- a/solar_host/backends/llamacpp.py
+++ b/solar_host/backends/llamacpp.py
@@ -1,12 +1,12 @@
 """LlamaCpp backend runner implementation."""
 
 import re
-from typing import List, Optional, Any, Dict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from typing import Any
 
 from solar_host.backends.base import BackendRunner, RuntimeStateUpdate
-from solar_host.models.base import InstancePhase, GenerationMetrics
 from solar_host.config import settings
+from solar_host.models.base import GenerationMetrics, InstancePhase
 
 
 class LlamaCppRunner(BackendRunner):
@@ -41,7 +41,7 @@ class LlamaCppRunner(BackendRunner):
     def get_backend_type(self) -> str:
         return "llamacpp"
 
-    def build_command(self, instance: Any) -> List[str]:
+    def build_command(self, instance: Any) -> list[str]:
         """Build llama-server command from instance config."""
         config = instance.config
         cmd = [
@@ -157,7 +157,7 @@ class LlamaCppRunner(BackendRunner):
     def get_health_endpoint(self) -> str:
         return "/health"
 
-    def get_supported_endpoints(self) -> List[str]:
+    def get_supported_endpoints(self) -> list[str]:
         return [
             "/v1/chat/completions",
             "/v1/completions",
@@ -166,7 +166,7 @@ class LlamaCppRunner(BackendRunner):
             "/v1/rerank",
         ]
 
-    def get_supported_endpoints_for_model_type(self, model_type: str) -> List[str]:
+    def get_supported_endpoints_for_model_type(self, model_type: str) -> list[str]:
         """Return endpoints based on llama.cpp model_type (llm, embedding, reranker)."""
         if model_type == "embedding":
             return ["/v1/embeddings", "/v1/models"]
@@ -174,7 +174,7 @@ class LlamaCppRunner(BackendRunner):
             return ["/v1/rerank", "/v1/models"]
         return ["/v1/chat/completions", "/v1/completions", "/v1/models"]
 
-    def initialize_context(self) -> Dict[str, Any]:
+    def initialize_context(self) -> dict[str, Any]:
         """Initialize parsing context for llama.cpp log parsing."""
         return {
             "active_slots": set(),
@@ -191,8 +191,8 @@ class LlamaCppRunner(BackendRunner):
         }
 
     def parse_log_line(
-        self, instance_id: str, line: str, context: Dict[str, Any]
-    ) -> Optional[RuntimeStateUpdate]:
+        self, instance_id: str, line: str, context: dict[str, Any]
+    ) -> RuntimeStateUpdate | None:
         """Parse a llama-server log line and return state update if changed."""
         slots = context.get("active_slots", set())
         last_state = context.get("last_state", {})
@@ -203,7 +203,7 @@ class LlamaCppRunner(BackendRunner):
         if m:
             try:
                 slot_id = int(m.group(1))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 slot_id = -1
             slots.add(slot_id)
             context["active_slots"] = slots
@@ -225,7 +225,7 @@ class LlamaCppRunner(BackendRunner):
                 slot_id = int(m.group(1))
                 task_id = int(m.group(2))
                 prompt_tokens = int(m.group(3))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 slot_id, task_id, prompt_tokens = -1, -1, None
             slots.add(slot_id)
             context["active_slots"] = slots
@@ -237,7 +237,7 @@ class LlamaCppRunner(BackendRunner):
                     "slot_id": slot_id,
                     "task_id": task_id,
                     "prompt_tokens": prompt_tokens,
-                    "started_at": datetime.now(timezone.utc).isoformat(),
+                    "started_at": datetime.now(UTC).isoformat(),
                 }
             )
             pending_by_slot[slot_id] = pending
@@ -260,7 +260,7 @@ class LlamaCppRunner(BackendRunner):
         if m:
             try:
                 progress = float(m.group(1))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 progress = None
             return self._create_update(
                 busy=True if len(slots) > 0 else last_state.get("busy", False),
@@ -294,7 +294,7 @@ class LlamaCppRunner(BackendRunner):
             try:
                 idx = int(m.group(1))
                 total = int(m.group(2))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 idx, total = None, None
             return self._create_update(
                 busy=True if len(slots) > 0 else last_state.get("busy", False),
@@ -320,7 +320,7 @@ class LlamaCppRunner(BackendRunner):
                 gen_tokens = int(m.group(2))
                 ms_per_tok = float(m.group(3))
                 tps = float(m.group(4))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 gen_tokens, ms_per_tok, tps = None, None, None
 
             # Update pending metrics for last active slot
@@ -366,7 +366,7 @@ class LlamaCppRunner(BackendRunner):
         if m:
             try:
                 slot_id = int(m.group(1))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 slot_id = -1
             if slot_id in slots:
                 slots.discard(slot_id)
@@ -384,7 +384,7 @@ class LlamaCppRunner(BackendRunner):
                     decode_tps=pending.get("decode_tps"),
                     decode_ms_per_token=pending.get("decode_ms_per_token"),
                     started_at=pending.get("started_at"),
-                    finished_at=datetime.now(timezone.utc).isoformat(),
+                    finished_at=datetime.now(UTC).isoformat(),
                 )
                 recent = context.get("recent_generations", [])
                 recent.append(metrics)
@@ -448,26 +448,26 @@ class LlamaCppRunner(BackendRunner):
         self,
         busy: bool,
         phase: InstancePhase,
-        prefill_progress: Optional[float],
+        prefill_progress: float | None,
         active_slots: int,
-        last_state: Dict[str, Any],
-        context: Dict[str, Any],
-        slot_id: Optional[int] = None,
-        task_id: Optional[int] = None,
-        prefill_prompt_tokens: Optional[int] = None,
-        generated_tokens: Optional[int] = None,
-        decode_tps: Optional[float] = None,
-        decode_ms_per_token: Optional[float] = None,
-        checkpoint_index: Optional[int] = None,
-        checkpoint_total: Optional[int] = None,
-    ) -> Optional[RuntimeStateUpdate]:
+        last_state: dict[str, Any],
+        context: dict[str, Any],
+        slot_id: int | None = None,
+        task_id: int | None = None,
+        prefill_prompt_tokens: int | None = None,
+        generated_tokens: int | None = None,
+        decode_tps: float | None = None,
+        decode_ms_per_token: float | None = None,
+        checkpoint_index: int | None = None,
+        checkpoint_total: int | None = None,
+    ) -> RuntimeStateUpdate | None:
         """Create a RuntimeStateUpdate if state has changed."""
         # Normalize prefill_progress
-        pp: Optional[float] = None
+        pp: float | None = None
         if prefill_progress is not None:
             try:
                 pp = float(prefill_progress)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pp = None
 
         # Check if state changed
@@ -520,9 +520,7 @@ class LlamaCppRunner(BackendRunner):
             checkpoint_total=checkpoint_total,
         )
 
-    def get_last_generation(
-        self, context: Dict[str, Any]
-    ) -> Optional[GenerationMetrics]:
+    def get_last_generation(self, context: dict[str, Any]) -> GenerationMetrics | None:
         """Get the last generation metrics from context."""
         recent = context.get("recent_generations", [])
         if not recent:

--- a/solar_host/config.py
+++ b/solar_host/config.py
@@ -5,18 +5,19 @@ import logging
 import os
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from solar_host.models.base import Instance, InstanceStatus
-from solar_host.models.llamacpp import LlamaCppConfig
 from solar_host.models.huggingface import (
     HuggingFaceCausalConfig,
     HuggingFaceClassificationConfig,
     HuggingFaceEmbeddingConfig,
     HuggingFaceVisionConfig,
 )
+from solar_host.models.llamacpp import LlamaCppConfig
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
-def migrate_config_data(config_data: Dict[str, Any]) -> Dict[str, Any]:
+def migrate_config_data(config_data: dict[str, Any]) -> dict[str, Any]:
     """Migrate legacy config data to new format.
 
     Adds backend_type to configs that don't have it (defaults to llamacpp).
@@ -122,7 +123,7 @@ def resolve_model_source(model_source: str) -> str:
     - repo://...
     - huggingface://...
     """
-    if model_source.startswith("repo://") or model_source.startswith("huggingface://"):
+    if model_source.startswith(("repo://", "huggingface://")):
         raise ValueError(
             "Model must be resolved via POST /models/pull before instance creation. "
             "Use local:// or provide model/model_id path."
@@ -153,7 +154,7 @@ def resolve_model_source(model_source: str) -> str:
     return str(resolved_path)
 
 
-def parse_instance_config(config_data: Dict[str, Any]) -> Any:
+def parse_instance_config(config_data: dict[str, Any]) -> Any:
     """Parse config data into the appropriate config type based on backend_type."""
     # Migrate first
     config_data = migrate_config_data(config_data)
@@ -199,11 +200,11 @@ class ConfigManager:
     loop thread and background log-reader threads.
     """
 
-    def __init__(self, config_file: Optional[str] = None):
+    def __init__(self, config_file: str | None = None):
         self._lock = threading.Lock()
         self.config_file = Path(config_file or settings.config_file)
-        self.instances: Dict[str, Instance] = {}
-        self.roles: List[str] = ["inference"]
+        self.instances: dict[str, Instance] = {}
+        self.roles: list[str] = ["inference"]
         self.load()
 
     def load(self):
@@ -231,10 +232,10 @@ class ConfigManager:
                             instance_data_copy["config"] = config
                             instance = Instance(**instance_data_copy)
                             self.instances[instance.id] = instance
-                        except Exception as e:
+                        except Exception as e:  # noqa: BLE001
                             logger.warning("Skipping instance during load: %s", e)
                             continue
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.error("Error loading config: %s", e)
                 self.instances = {}
         else:
@@ -255,7 +256,7 @@ class ConfigManager:
             with open(tmp, "w") as f:
                 json.dump(data, f, indent=2, default=str)
             os.replace(tmp, self.config_file)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error("Error saving config: %s", e)
 
     def save(self):
@@ -296,17 +297,17 @@ class ConfigManager:
                 del self.instances[instance_id]
                 self._save_unlocked()
 
-    def get_instance(self, instance_id: str) -> Optional[Instance]:
+    def get_instance(self, instance_id: str) -> Instance | None:
         """Get an instance by ID."""
         with self._lock:
             return self.instances.get(instance_id)
 
-    def get_all_instances(self) -> List[Instance]:
+    def get_all_instances(self) -> list[Instance]:
         """Get all instances."""
         with self._lock:
             return list(self.instances.values())
 
-    def get_running_instances(self) -> List[Instance]:
+    def get_running_instances(self) -> list[Instance]:
         """Get all running instances."""
         with self._lock:
             return [

--- a/solar_host/docker/__init__.py
+++ b/solar_host/docker/__init__.py
@@ -11,12 +11,12 @@ from solar_host.docker.errors import (
 from solar_host.docker.service import ContainerStatus, DockerService
 
 __all__ = [
-    "DockerService",
-    "ContainerStatus",
-    "DockerServiceError",
-    "DaemonUnavailableError",
-    "ImagePullError",
-    "ContainerStartError",
     "ContainerNonZeroExitError",
+    "ContainerStartError",
+    "ContainerStatus",
+    "DaemonUnavailableError",
+    "DockerService",
+    "DockerServiceError",
     "GpuUnavailableError",
+    "ImagePullError",
 ]

--- a/solar_host/docker/service.py
+++ b/solar_host/docker/service.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Iterator, Union, overload
+from typing import Literal, overload
 
 import docker
 import docker.errors as _docker_errors
 
-from solar_host.config import Settings, settings as _default_settings
+from solar_host.config import Settings
+from solar_host.config import settings as _default_settings
 from solar_host.docker.errors import (
     ContainerNonZeroExitError,
     ContainerStartError,
@@ -84,7 +86,7 @@ class DockerService:
         try:
             info = self._client.info()
             return "nvidia" in (info.get("Runtimes") or {})
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     def create_container(
@@ -274,7 +276,7 @@ class DockerService:
         follow: bool = True,
         tail: int = 50,
         demux: bool = False,
-    ) -> Union[Iterator[str], Iterator[tuple[str, str]]]:
+    ) -> Iterator[str] | Iterator[tuple[str, str]]:
         """Yield decoded log chunks from the container.
 
         Args:
@@ -289,7 +291,7 @@ class DockerService:
         """
         try:
             container = self._client.containers.get(container_id)
-            tail_arg: Union[int, str] = tail if tail > 0 else "all"
+            tail_arg: int | str = tail if tail > 0 else "all"
 
             if demux:
                 log_stream = container.logs(
@@ -340,7 +342,7 @@ class DockerService:
             try:
                 raw = container.logs(stdout=False, stderr=True, tail=20)
                 stderr_lines = raw.decode("utf-8", errors="replace").splitlines()
-            except Exception:
+            except Exception:  # noqa: S110, BLE001
                 pass
             raise ContainerNonZeroExitError(container_id, exit_code, stderr_lines)
 

--- a/solar_host/jobs/__init__.py
+++ b/solar_host/jobs/__init__.py
@@ -21,25 +21,25 @@ from solar_host.jobs.models import (
 from solar_host.jobs.store import JobStore, job_store
 
 __all__ = [
-    # errors
-    "JobsError",
-    "WorkspaceError",
-    "InvalidJobIdError",
-    "InsufficientDiskError",
+    "GpuOptions",
     "GpuValidationError",
+    "InsufficientDiskError",
+    "InvalidJobIdError",
+    "JobDefinition",
     # executor
     "JobExecutor",
-    "cleanup_loop",
+    "JobState",
     # models
     "JobStatus",
-    "StepStatus",
-    "GpuOptions",
-    "StepDefinition",
-    "JobDefinition",
-    "StepState",
-    "JobState",
-    "StepLogMessage",
     # store
     "JobStore",
+    # errors
+    "JobsError",
+    "StepDefinition",
+    "StepLogMessage",
+    "StepState",
+    "StepStatus",
+    "WorkspaceError",
+    "cleanup_loop",
     "job_store",
 ]

--- a/solar_host/jobs/events.py
+++ b/solar_host/jobs/events.py
@@ -9,13 +9,8 @@ per-event handlers (S-032).
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
 
 from solar_host.ws_client import broadcast_job_lifecycle, get_client
-
-if TYPE_CHECKING:
-    pass
-
 
 # ---------------------------------------------------------------------------
 # Internal helpers

--- a/solar_host/jobs/executor.py
+++ b/solar_host/jobs/executor.py
@@ -259,7 +259,7 @@ class JobExecutor:
             )
             try:
                 await asyncio.to_thread(self._docker.stop_container, active_container)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 logger.warning(
                     "Error stopping container %s during cancel of job %r",
                     active_container,

--- a/solar_host/jobs/models.py
+++ b/solar_host/jobs/models.py
@@ -59,7 +59,7 @@ class GpuOptions(BaseModel):
     device_ids: list[str] | None = None
 
     @model_validator(mode="after")
-    def _require_count_or_device_ids(self) -> "GpuOptions":
+    def _require_count_or_device_ids(self) -> GpuOptions:
         if self.count is None and self.device_ids is None:
             raise ValueError("gpu options require count or device_ids")
         return self

--- a/solar_host/jobs/step_executor.py
+++ b/solar_host/jobs/step_executor.py
@@ -144,7 +144,7 @@ class JobStepExecutor:
                     await asyncio.to_thread(
                         self._docker.remove_container, container_id, True
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     logger.warning(
                         "Failed to remove container %s for step %r in job %r",
                         container_id,
@@ -300,7 +300,7 @@ class JobStepExecutor:
                     step_log_buffer.append(
                         job_id, step_name, step_index, stream_tag, chunk
                     )
-        except Exception:
+        except Exception:  # noqa: BLE001
             logger.debug(
                 "Log streaming finished for container %s → %s", container_id, log_path
             )
@@ -310,5 +310,5 @@ class JobStepExecutor:
         """Wait for the log-streaming future with a short timeout (best effort)."""
         try:
             await asyncio.wait_for(log_future, timeout=5.0)
-        except Exception:
+        except Exception:  # noqa: S110, BLE001
             pass

--- a/solar_host/jobs/store.py
+++ b/solar_host/jobs/store.py
@@ -77,7 +77,7 @@ class JobStore:
         for item in data:
             try:
                 state = JobState(**item)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 logger.warning("Skipping malformed job entry in %s: %s", path, item)
                 continue
 

--- a/solar_host/main.py
+++ b/solar_host/main.py
@@ -10,14 +10,14 @@ from fastapi.responses import JSONResponse
 
 from solar_host import __version__
 from solar_host.config import settings
-from solar_host.models.base import BackendType
-from solar_host.models_manager import ensure_models_dir, get_models_dir
-from solar_host.process_manager import process_manager
-from solar_host.routes import instances, jobs, models, websockets, resources
-from solar_host.ws_client import init_clients, get_clients, get_client, broadcast_health
 from solar_host.jobs import JobExecutor, cleanup_loop, job_store
 from solar_host.jobs.step_log_buffer import step_log_flush_loop
 from solar_host.jobs.workspace import ensure_jobs_dir
+from solar_host.models.base import BackendType
+from solar_host.models_manager import ensure_models_dir, get_models_dir
+from solar_host.process_manager import process_manager
+from solar_host.routes import instances, jobs, models, resources, websockets
+from solar_host.ws_client import broadcast_health, get_client, get_clients, init_clients
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def health_report_loop(app: FastAPI):
                 await broadcast_health(resource_manager=rm)
         except asyncio.CancelledError:
             break
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("Health report error: %s", e)
 
 
@@ -47,7 +47,7 @@ async def resource_usage_poll_loop(app: FastAPI, interval: float = 10.0):
                 await manager.refresh_usage_async()
         except asyncio.CancelledError:
             break
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning("resource_usage_poll_loop error: %s", exc)
 
 
@@ -61,7 +61,7 @@ async def reservation_cleanup_loop(app: FastAPI, interval: float = 60.0):
                 manager.cleanup_expired(now=datetime.now(UTC))
         except asyncio.CancelledError:
             break
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning("reservation_cleanup_loop error: %s", exc)
 
 
@@ -93,8 +93,8 @@ async def lifespan(app: FastAPI):
     logger.info("HF cache directory: %s", settings.hf_cache_dir)
 
     # --- Job execution layer ---
-    from solar_host.docker.service import DockerService
     from solar_host.docker.errors import DaemonUnavailableError
+    from solar_host.docker.service import DockerService
 
     docker_service: DockerService | None = None
     job_executor: JobExecutor | None = None
@@ -172,7 +172,7 @@ async def lifespan(app: FastAPI):
             if job.status == _JobStatus.running:
                 try:
                     await job_executor.cancel_job(job.job_id)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     logger.warning(
                         "Error cancelling job %r during shutdown", job.job_id
                     )
@@ -333,6 +333,7 @@ async def root():
 async def get_memory():
     """Get GPU/RAM memory usage"""
     from fastapi import HTTPException
+
     from solar_host.memory_monitor import get_memory_info
     from solar_host.models import MemoryInfo
 

--- a/solar_host/memory_monitor.py
+++ b/solar_host/memory_monitor.py
@@ -7,19 +7,19 @@ import platform
 import shutil
 import time
 from pathlib import Path
-from typing import Optional, Dict, Union
+
 import psutil
 
 # Cache for memory info to avoid excessive polling
-_memory_cache: Optional[Dict] = None
+_memory_cache: dict | None = None
 _cache_timestamp: float = 0
 CACHE_DURATION = 5.0  # seconds
 
 # GPU type is constant for the lifetime of the process
-_gpu_type_cache: Optional[str] = None
+_gpu_type_cache: str | None = None
 
 
-def get_memory_info() -> Optional[Dict[str, Union[float, str]]]:
+def get_memory_info() -> dict[str, float | str] | None:
     """
     Get memory information based on platform.
 
@@ -75,7 +75,7 @@ def detect_gpu_type() -> str:
             _gpu_type_cache = "nvidia_cuda"
             return _gpu_type_cache
         pynvml.nvmlShutdown()
-    except Exception:
+    except Exception:  # noqa: S110, BLE001
         pass
 
     if platform.system() == "Darwin":
@@ -86,7 +86,7 @@ def detect_gpu_type() -> str:
     return _gpu_type_cache
 
 
-def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:
+def _get_nvidia_memory() -> dict[str, float | str] | None:
     """Get combined VRAM from all NVIDIA GPUs."""
     try:
         import pynvml  # type: ignore
@@ -119,11 +119,11 @@ def _get_nvidia_memory() -> Optional[Dict[str, Union[float, str]]]:
             "percent": round(percent, 2),
             "memory_type": "VRAM",
         }
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
-def _get_system_memory() -> Optional[Dict[str, Union[float, str]]]:
+def _get_system_memory() -> dict[str, float | str] | None:
     """Get system RAM info via psutil (fallback for Linux without NVIDIA)."""
     try:
         mem = psutil.virtual_memory()
@@ -137,11 +137,11 @@ def _get_system_memory() -> Optional[Dict[str, Union[float, str]]]:
             "percent": round(mem.percent, 2),
             "memory_type": "RAM",
         }
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
-def _get_mac_memory() -> Optional[Dict[str, Union[float, str]]]:
+def _get_mac_memory() -> dict[str, float | str] | None:
     """Get unified memory info on macOS."""
     try:
         mem = psutil.virtual_memory()
@@ -160,7 +160,7 @@ def _get_mac_memory() -> Optional[Dict[str, Union[float, str]]]:
             "percent": round(percent, 2),
             "memory_type": "RAM",
         }
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -195,7 +195,7 @@ def get_gpu_devices() -> list[dict[str, object]]:
         finally:
             pynvml.nvmlShutdown()
         return devices
-    except Exception:
+    except Exception:  # noqa: BLE001
         return []
 
 
@@ -210,7 +210,7 @@ def get_gpu_process_memory() -> dict[int, int]:
     # process's per-PID GPU memory can't be read (e.g. insufficient permissions
     # or MIG). The Python binding surfaces this as a huge sentinel or None;
     # accumulating it would wildly inflate usage, so we discard such values.
-    def _valid(used: object) -> Optional[int]:
+    def _valid(used: object) -> int | None:
         if used is None:
             return None
         try:
@@ -239,16 +239,16 @@ def get_gpu_process_memory() -> dict[int, int]:
                         used = _valid(proc.usedGpuMemory)
                         if used is not None:
                             pid_bytes[proc.pid] = pid_bytes.get(proc.pid, 0) + used
-                except Exception:
+                except Exception:  # noqa: S110, BLE001
                     pass
         finally:
             pynvml.nvmlShutdown()
         return pid_bytes
-    except Exception:
+    except Exception:  # noqa: BLE001
         return {}
 
 
-def get_disk_info(path: str) -> Optional[Dict[str, float]]:
+def get_disk_info(path: str) -> dict[str, float] | None:
     """Return disk usage stats (in GB) for the filesystem containing *path*.
 
     Walks up to the nearest existing parent if *path* itself doesn't exist.
@@ -264,5 +264,5 @@ def get_disk_info(path: str) -> Optional[Dict[str, float]]:
             "used_gb": round(usage.used / (1024**3), 2),
             "available_gb": round(usage.free / (1024**3), 2),
         }
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None

--- a/solar_host/models/__init__.py
+++ b/solar_host/models/__init__.py
@@ -1,27 +1,25 @@
 """Models package for solar-host with multi-backend support."""
 
-from typing import Union, Annotated
+from typing import Annotated
+
 from pydantic import Field
 
 # Import base models first (no dependencies on config types)
 from solar_host.models.base import (
     BackendType,
-    InstanceStatus,
-    InstancePhase,
-    InstancePriority,
+    GenerationMetrics,
     Instance,
     InstanceCreate,
-    InstanceUpdate,
-    LogMessage,
+    InstancePhase,
+    InstancePriority,
+    InstanceResponse,
     InstanceRuntimeState,
     InstanceStateEvent,
-    InstanceResponse,
+    InstanceStatus,
+    InstanceUpdate,
+    LogMessage,
     MemoryInfo,
-    GenerationMetrics,
 )
-
-# Import config models
-from solar_host.models.llamacpp import LlamaCppConfig
 from solar_host.models.huggingface import (
     HuggingFaceCausalConfig,
     HuggingFaceClassificationConfig,
@@ -29,41 +27,42 @@ from solar_host.models.huggingface import (
     HuggingFaceVisionConfig,
 )
 
+# Import config models
+from solar_host.models.llamacpp import LlamaCppConfig
+
 # Create the discriminated union type for InstanceConfig
 InstanceConfig = Annotated[
-    Union[
-        LlamaCppConfig,
-        HuggingFaceCausalConfig,
-        HuggingFaceClassificationConfig,
-        HuggingFaceEmbeddingConfig,
-        HuggingFaceVisionConfig,
-    ],
+    LlamaCppConfig
+    | HuggingFaceCausalConfig
+    | HuggingFaceClassificationConfig
+    | HuggingFaceEmbeddingConfig
+    | HuggingFaceVisionConfig,
     Field(discriminator="backend_type"),
 ]
 
 __all__ = [
     # Enums
     "BackendType",
-    "InstanceStatus",
-    "InstancePhase",
-    "InstancePriority",
-    # Config types
-    "InstanceConfig",
-    "LlamaCppConfig",
+    "GenerationMetrics",
     "HuggingFaceCausalConfig",
     "HuggingFaceClassificationConfig",
     "HuggingFaceEmbeddingConfig",
     "HuggingFaceVisionConfig",
     # Instance models
     "Instance",
+    # Config types
+    "InstanceConfig",
     "InstanceCreate",
-    "InstanceUpdate",
+    "InstancePhase",
+    "InstancePriority",
     "InstanceResponse",
-    # Runtime models
-    "LogMessage",
     "InstanceRuntimeState",
     "InstanceStateEvent",
-    "GenerationMetrics",
+    "InstanceStatus",
+    "InstanceUpdate",
+    "LlamaCppConfig",
+    # Runtime models
+    "LogMessage",
     # Other
     "MemoryInfo",
 ]

--- a/solar_host/models/base.py
+++ b/solar_host/models/base.py
@@ -1,9 +1,10 @@
 """Base models shared across all backend types."""
 
-from pydantic import BaseModel, Field
-from typing import Optional, List, Any
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class BackendType(str, Enum):
@@ -56,17 +57,17 @@ class InstanceRuntimeState(BaseModel):
     instance_id: str
     busy: bool
     phase: InstancePhase = InstancePhase.IDLE
-    prefill_progress: Optional[float] = None
+    prefill_progress: float | None = None
     active_slots: int = 0
     # Optional contextual metrics
-    slot_id: Optional[int] = None
-    task_id: Optional[int] = None
-    prefill_prompt_tokens: Optional[int] = None
-    generated_tokens: Optional[int] = None
-    decode_tps: Optional[float] = None
-    decode_ms_per_token: Optional[float] = None
-    checkpoint_index: Optional[int] = None
-    checkpoint_total: Optional[int] = None
+    slot_id: int | None = None
+    task_id: int | None = None
+    prefill_prompt_tokens: int | None = None
+    generated_tokens: int | None = None
+    decode_tps: float | None = None
+    decode_ms_per_token: float | None = None
+    checkpoint_index: int | None = None
+    checkpoint_total: int | None = None
     timestamp: str
 
 
@@ -95,20 +96,20 @@ class GenerationMetrics(BaseModel):
     """Per-generation token usage and timing metrics."""
 
     instance_id: str
-    slot_id: Optional[int] = None
-    task_id: Optional[int] = None
+    slot_id: int | None = None
+    task_id: int | None = None
 
     # Token usage
-    prompt_tokens: Optional[int] = None
-    generated_tokens: Optional[int] = None
+    prompt_tokens: int | None = None
+    generated_tokens: int | None = None
 
     # Decode performance
-    decode_tps: Optional[float] = None
-    decode_ms_per_token: Optional[float] = None
+    decode_tps: float | None = None
+    decode_ms_per_token: float | None = None
 
     # Timestamps
-    started_at: Optional[str] = None
-    finished_at: Optional[str] = None
+    started_at: str | None = None
+    finished_at: str | None = None
 
 
 class Instance(BaseModel):
@@ -121,11 +122,11 @@ class Instance(BaseModel):
     id: str
     config: Any  # InstanceConfig - discriminated union
     status: InstanceStatus = InstanceStatus.STOPPED
-    port: Optional[int] = None
-    pid: Optional[int] = None
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    started_at: Optional[datetime] = None
-    error_message: Optional[str] = None
+    port: int | None = None
+    pid: int | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    started_at: datetime | None = None
+    error_message: str | None = None
     retry_count: int = 0
 
     # Priority and ownership (S-036)
@@ -133,21 +134,21 @@ class Instance(BaseModel):
         default=InstancePriority.PRODUCTION,
         description="Instance priority for placement and eviction decisions",
     )
-    managed_by: Optional[str] = Field(
+    managed_by: str | None = Field(
         default=None,
         description="Owner subsystem (e.g. 'intent' for reconciler-managed instances)",
     )
-    intent_id: Optional[str] = Field(
+    intent_id: str | None = Field(
         default=None,
         description="Owning intent ID (set iff managed_by == 'intent')",
     )
 
     # Supported API endpoints for this instance (populated by backend runner)
-    supported_endpoints: List[str] = Field(default_factory=list)
+    supported_endpoints: list[str] = Field(default_factory=list)
 
     # Ephemeral runtime fields (not persisted to disk)
     busy: bool = Field(default=False, exclude=True)
-    prefill_progress: Optional[float] = Field(default=None, exclude=True)
+    prefill_progress: float | None = Field(default=None, exclude=True)
     active_slots: int = Field(default=0, exclude=True)
 
 
@@ -158,9 +159,9 @@ class InstanceCreate(BaseModel):
     """
 
     config: Any  # InstanceConfig
-    priority: Optional[str] = None
-    managed_by: Optional[str] = None
-    intent_id: Optional[str] = None
+    priority: str | None = None
+    managed_by: str | None = None
+    intent_id: str | None = None
 
 
 class InstanceUpdate(BaseModel):
@@ -171,9 +172,9 @@ class InstanceUpdate(BaseModel):
     (``managed_by``/``intent_id`` may be set to null to clear ownership).
     """
 
-    config: Optional[Any] = None  # InstanceConfig
-    managed_by: Optional[str] = None
-    intent_id: Optional[str] = None
+    config: Any | None = None  # InstanceConfig
+    managed_by: str | None = None
+    intent_id: str | None = None
 
 
 class InstanceResponse(BaseModel):

--- a/solar_host/models/huggingface.py
+++ b/solar_host/models/huggingface.py
@@ -1,7 +1,8 @@
 """HuggingFace backend configuration models."""
 
-from pydantic import BaseModel, Field, ConfigDict, model_validator
-from typing import Optional, List, Literal, Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 def _strip_api_key(data: Any) -> Any:
@@ -27,10 +28,10 @@ class HuggingFaceCausalConfig(BaseModel):
     backend_type: Literal["huggingface_causal"] = Field(
         default="huggingface_causal", description="Backend type identifier"
     )
-    model_source: Optional[str] = Field(
+    model_source: str | None = Field(
         default=None, description="Model source URI (e.g. local://model_dir)"
     )
-    model_id: Optional[str] = Field(
+    model_id: str | None = Field(
         default=None,
         description="HuggingFace model ID or local path (e.g., 'meta-llama/Llama-2-7b-hf')",
     )
@@ -56,7 +57,7 @@ class HuggingFaceCausalConfig(BaseModel):
         default=True, description="Use Flash Attention 2 if available"
     )
     host: str = Field(default="0.0.0.0", description="Host to bind to")
-    port: Optional[int] = Field(
+    port: int | None = Field(
         default=None, description="Port (auto-assigned if not specified)"
     )
 
@@ -77,10 +78,10 @@ class HuggingFaceClassificationConfig(BaseModel):
     backend_type: Literal["huggingface_classification"] = Field(
         default="huggingface_classification", description="Backend type identifier"
     )
-    model_source: Optional[str] = Field(
+    model_source: str | None = Field(
         default=None, description="Model source URI (e.g. local://model_dir)"
     )
-    model_id: Optional[str] = Field(
+    model_id: str | None = Field(
         default=None, description="HuggingFace model ID or local path"
     )
 
@@ -100,14 +101,14 @@ class HuggingFaceClassificationConfig(BaseModel):
     max_length: int = Field(
         default=512, description="Maximum sequence length for classification"
     )
-    labels: Optional[List[str]] = Field(
+    labels: list[str] | None = Field(
         default=None, description="Optional label names mapping (index -> label name)"
     )
     trust_remote_code: bool = Field(
         default=False, description="Whether to trust remote code from HuggingFace"
     )
     host: str = Field(default="0.0.0.0", description="Host to bind to")
-    port: Optional[int] = Field(
+    port: int | None = Field(
         default=None, description="Port (auto-assigned if not specified)"
     )
 
@@ -128,10 +129,10 @@ class HuggingFaceEmbeddingConfig(BaseModel):
     backend_type: Literal["huggingface_embedding"] = Field(
         default="huggingface_embedding", description="Backend type identifier"
     )
-    model_source: Optional[str] = Field(
+    model_source: str | None = Field(
         default=None, description="Model source URI (e.g. local://model_dir)"
     )
-    model_id: Optional[str] = Field(
+    model_id: str | None = Field(
         default=None,
         description="HuggingFace model ID or local path (e.g., 'sentence-transformers/all-MiniLM-L6-v2')",
     )
@@ -159,7 +160,7 @@ class HuggingFaceEmbeddingConfig(BaseModel):
         default=False, description="Whether to trust remote code from HuggingFace"
     )
     host: str = Field(default="0.0.0.0", description="Host to bind to")
-    port: Optional[int] = Field(
+    port: int | None = Field(
         default=None, description="Port (auto-assigned if not specified)"
     )
 
@@ -183,10 +184,10 @@ class HuggingFaceVisionConfig(BaseModel):
     backend_type: Literal["huggingface_vision"] = Field(
         default="huggingface_vision", description="Backend type identifier"
     )
-    model_source: Optional[str] = Field(
+    model_source: str | None = Field(
         default=None, description="Model source URI (e.g. local://model_dir)"
     )
-    model_id: Optional[str] = Field(
+    model_id: str | None = Field(
         default=None,
         description="HuggingFace model ID or local path (e.g., 'Qwen/Qwen2.5-VL-7B-Instruct')",
     )
@@ -212,6 +213,6 @@ class HuggingFaceVisionConfig(BaseModel):
         default=True, description="Use Flash Attention 2 if available"
     )
     host: str = Field(default="0.0.0.0", description="Host to bind to")
-    port: Optional[int] = Field(
+    port: int | None = Field(
         default=None, description="Port (auto-assigned if not specified)"
     )

--- a/solar_host/models/llamacpp.py
+++ b/solar_host/models/llamacpp.py
@@ -1,6 +1,6 @@
 """LlamaCpp backend configuration models."""
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -25,12 +25,10 @@ class LlamaCppConfig(BaseModel):
             data.pop("api_key", None)
         return data
 
-    model_source: Optional[str] = Field(
+    model_source: str | None = Field(
         default=None, description="Model source URI (e.g. local://path/to/model.gguf)"
     )
-    model: Optional[str] = Field(
-        default=None, description="Path to the GGUF model file"
-    )
+    model: str | None = Field(default=None, description="Path to the GGUF model file")
 
     @model_validator(mode="after")
     def check_model_or_source(self) -> "LlamaCppConfig":
@@ -38,7 +36,7 @@ class LlamaCppConfig(BaseModel):
             raise ValueError("Either 'model' or 'model_source' must be provided")
         return self
 
-    mmproj: Optional[str] = Field(
+    mmproj: str | None = Field(
         default=None,
         description="Path to multimodal projector GGUF file for vision models",
     )
@@ -54,60 +52,62 @@ class LlamaCppConfig(BaseModel):
     top_k: int = Field(default=0, description="Top-k sampling")
     min_p: float = Field(default=0.0, description="Min-p sampling")
     ctx_size: int = Field(default=131072, description="Context size")
-    chat_template_file: Optional[str] = Field(
+    chat_template_file: str | None = Field(
         default=None, description="Path to Jinja chat template"
     )
-    chat_template_kwargs: Optional[str] = Field(
+    chat_template_kwargs: str | None = Field(
         default=None,
         description="JSON string of chat template kwargs (e.g. '{\"enable_thinking\":true}')",
     )
-    reasoning: Optional[Literal["on", "off", "auto"]] = Field(
+    reasoning: Literal["on", "off", "auto"] | None = Field(
         default=None,
         description="Reasoning/thinking mode: 'on', 'off', or 'auto' (passed as --reasoning to llama-server)",
     )
-    reasoning_budget: Optional[int] = Field(
+    reasoning_budget: int | None = Field(
         default=None,
         description="Reasoning budget token limit (passed as --reasoning-budget to llama-server)",
     )
-    spec_type: Optional[Literal["draft-mtp"]] = Field(
+    spec_type: Literal["draft-mtp"] | None = Field(
         default=None,
         description="Speculative decoding type (passed as --spec-type to llama-server)",
     )
-    spec_draft_n_max: Optional[int] = Field(
+    spec_draft_n_max: int | None = Field(
         default=None,
         ge=1,
         description="Maximum speculative draft tokens (passed as --spec-draft-n-max to llama-server)",
     )
-    cache_type_k: Optional[
+    cache_type_k: (
         Literal["f32", "f16", "bf16", "q8_0", "q4_0", "q4_1", "iq4_nl", "q5_0", "q5_1"]
-    ] = Field(default=None, description="KV cache quantization type for keys (-ctk)")
-    cache_type_v: Optional[
+        | None
+    ) = Field(default=None, description="KV cache quantization type for keys (-ctk)")
+    cache_type_v: (
         Literal["f32", "f16", "bf16", "q8_0", "q4_0", "q4_1", "iq4_nl", "q5_0", "q5_1"]
-    ] = Field(default=None, description="KV cache quantization type for values (-ctv)")
-    rope_scaling: Optional[Literal["none", "linear", "yarn"]] = Field(
+        | None
+    ) = Field(default=None, description="KV cache quantization type for values (-ctv)")
+    rope_scaling: Literal["none", "linear", "yarn"] | None = Field(
         default=None, description="RoPE scaling method (--rope-scaling)"
     )
-    rope_scale: Optional[float] = Field(
+    rope_scale: float | None = Field(
         default=None, description="RoPE context scaling factor (--rope-scale)"
     )
-    yarn_orig_ctx: Optional[int] = Field(
+    yarn_orig_ctx: int | None = Field(
         default=None, description="YaRN original context size (--yarn-orig-ctx)"
     )
     host: str = Field(default="0.0.0.0", description="Host to bind to")
-    port: Optional[int] = Field(
+    port: int | None = Field(
         default=None, description="Port (auto-assigned if not specified)"
     )
     special: bool = Field(
         default=False, description="Enable llama-server --special flag"
     )
-    ot: Optional[str] = Field(
+    ot: str | None = Field(
         default=None,
         description="Override tensor string (passed as -ot flag to llama-server)",
     )
-    model_type: Optional[Literal["llm", "embedding", "reranker"]] = Field(
+    model_type: Literal["llm", "embedding", "reranker"] | None = Field(
         default="llm", description="Model type: llm (default), embedding, or reranker"
     )
-    pooling: Optional[Literal["none", "mean", "cls", "last", "rank"]] = Field(
+    pooling: Literal["none", "mean", "cls", "last", "rank"] | None = Field(
         default=None,
         description="Pooling strategy for embedding models (only valid when model_type is embedding)",
     )

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -9,6 +9,7 @@ cache detection.
 """
 
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -18,7 +19,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 import pebble
@@ -56,6 +57,10 @@ class ManifestEntry(BaseModel):
     version: Optional[str] = None
     checksum: Optional[str] = None
     metadata: Optional[dict] = None
+    # Per-file sha256 (hex) of the pulled artifact, recorded at pull time
+    # and verified on every cache hit (D-017). Absent on entries created
+    # before this field existed — readers must treat it as optional.
+    file_digests: Optional[dict] = None
 
 
 class Manifest(BaseModel):
@@ -305,8 +310,14 @@ def _pull_harbor(
     harbor_ref: str,
     target_dir: Path,
     source_uri: str,
-) -> None:
+) -> Optional[dict]:
     """Download a Harbor OCI artifact via ORAS into *target_dir*.
+
+    Verifies every pulled file's sha256 against the OCI manifest layer
+    digests (flat layers: layer digest = sha256 of the exact file bytes)
+    and returns ``{filename: sha256-hex}`` for the verified files. Raises
+    ``ModelPullError`` (502 model_pull_failed) on any mismatch so the
+    caller's retry/backoff surfaces it.
 
     Credentials must have been validated by the caller before this is invoked.
     """
@@ -321,6 +332,108 @@ def _pull_harbor(
         password=settings.harbor_password,
     )
     oras.pull(harbor_ref, outdir=str(target_dir))
+    return _verify_pulled_digests(oras, harbor_ref, target_dir, source_uri)
+
+
+def _verify_pulled_digests(
+    oras: Any,
+    harbor_ref: str,
+    target_dir: Path,
+    source_uri: str,
+) -> Optional[dict]:
+    """Verify on-disk pulled files against the OCI manifest layer digests.
+
+    Uses the shared client's authenticated manifest fetch (the public
+    ``OrasHelper`` API does not expose manifests yet — follow-up: add a
+    ``get_manifest_layers`` method to harbor-oci-client). If the manifest
+    cannot be fetched or carries no per-file digests, verification is
+    skipped (log warning) rather than failing the pull.
+
+    Returns ``{filename: sha256-hex}`` of verified files, or None when
+    verification was not possible.
+    """
+    try:
+        manifest = oras._client.get_manifest(harbor_ref)  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Post-pull digest verification skipped for %s: manifest fetch failed: %s",
+            harbor_ref,
+            exc,
+        )
+        return None
+
+    expected: dict[str, str] = {}
+    for layer in manifest.get("layers", []):
+        title = (layer.get("annotations") or {}).get(
+            "org.opencontainers.image.title"
+        )
+        digest = layer.get("digest", "")
+        if title and digest.startswith("sha256:"):
+            expected[title] = digest[len("sha256:") :]
+
+    if not expected:
+        logger.warning(
+            "Post-pull digest verification skipped for %s: manifest has no "
+            "per-file layer digests",
+            harbor_ref,
+        )
+        return None
+
+    problems: list[str] = []
+    actual: dict[str, str] = {}
+    for path in target_dir.iterdir():
+        if not path.is_file():
+            continue
+        h = hashlib.sha256(path.read_bytes()).hexdigest()
+        actual[path.name] = h
+        want = expected.get(path.name)
+        if want is None:
+            logger.warning(
+                "Pulled file %s is not covered by the manifest for %s",
+                path.name,
+                harbor_ref,
+            )
+        elif h != want:
+            problems.append(
+                f"{path.name}: digest mismatch (got {h}, want {want})"
+            )
+    for name in expected:
+        if name not in actual:
+            problems.append(f"{name}: missing on disk after pull")
+
+    if problems:
+        raise ModelPullError(
+            502,
+            "model_pull_failed",
+            f"Pulled artifact integrity check failed: {'; '.join(problems)}",
+            source_uri,
+        )
+    return actual
+
+
+def _verify_cached_digests(entry: "ManifestEntry") -> bool:
+    """Verify on-disk artifact files against the manifest entry's digests.
+
+    Entries without recorded digests (pre-D-017) are trusted as-is.
+    """
+    if not entry.file_digests:
+        return True
+    base = Path(entry.path)
+    for name, want in entry.file_digests.items():
+        f = base / name
+        if not f.is_file():
+            logger.warning(
+                "Cached artifact %s corrupt: %s missing", entry.source_uri, name
+            )
+            return False
+        if hashlib.sha256(f.read_bytes()).hexdigest() != want:
+            logger.warning(
+                "Cached artifact %s corrupt: %s digest mismatch",
+                entry.source_uri,
+                name,
+            )
+            return False
+    return True
 
 
 def _pull_huggingface(
@@ -389,21 +502,22 @@ def pull_model(
 
         # 2. Cache check — manifest is the single source of truth, keyed by
         #    the base URI (the artifact identity).  Verify the resolved path
-        #    (dir + optional subpath) still exists on disk.
+        #    (dir + optional subpath) still exists on disk AND the recorded
+        #    per-file digests still match (a corrupt cached artifact would
+        #    otherwise keep crashing every restart-in-place RECREATE).
         cached_entry = get_manifest_entry(cache_key)
         if cached_entry is not None:
             cached_path = Path(cached_entry.path)
             resolved_cache = cached_path / subpath if subpath else cached_path
-            if resolved_cache.exists():
+            if resolved_cache.exists() and _verify_cached_digests(cached_entry):
                 return {
                     "path": str(resolved_cache),
                     "cached": True,
                     "source_uri": source_uri,
                 }
             logger.warning(
-                "Manifest entry for %s points to missing path %s, re-pulling",
+                "Manifest entry for %s is missing or corrupt on disk, re-pulling",
                 cache_key,
-                cached_entry.path,
             )
             with _manifest_lock:
                 remove_manifest_entry(cache_key)
@@ -455,6 +569,7 @@ def pull_model(
 
         # 6. Download — subprocess + polling allows aborting on low disk (S-018).
         # In-process mode skips the worker (used by unit tests that mock pull funcs).
+        file_digests: Optional[dict] = None
         try:
             if settings.pull_use_subprocess:
                 poll_s = max(0.05, settings.pull_disk_poll_interval_s)
@@ -487,10 +602,12 @@ def pull_model(
                                 source_uri,
                             )
 
-                    future.result()
+                    file_digests = future.result()
             else:
                 if source == "harbor":
-                    _pull_harbor(harbor_ref or "", target_dir, source_uri)
+                    file_digests = _pull_harbor(
+                        harbor_ref or "", target_dir, source_uri
+                    )
                 else:
                     _pull_huggingface(model_id or "", target_dir, source_uri)
         except ModelPullError:
@@ -550,6 +667,7 @@ def pull_model(
             version=version,
             checksum=checksum,
             metadata=metadata,
+            file_digests=file_digests,
         )
         with _manifest_lock:
             add_manifest_entry(entry)

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -17,9 +17,9 @@ import re
 import shutil
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 import pebble
@@ -50,17 +50,17 @@ class ManifestEntry(BaseModel):
     source_uri: str
     path: str
     size_bytes: int
-    digest: Optional[str] = None
+    digest: str | None = None
     downloaded_at: str
-    category: Optional[str] = None
-    name: Optional[str] = None
-    version: Optional[str] = None
-    checksum: Optional[str] = None
-    metadata: Optional[dict] = None
+    category: str | None = None
+    name: str | None = None
+    version: str | None = None
+    checksum: str | None = None
+    metadata: dict | None = None
     # Per-file sha256 (hex) of the pulled artifact, recorded at pull time
     # and verified on every cache hit (D-017). Absent on entries created
     # before this field existed — readers must treat it as optional.
-    file_digests: Optional[dict] = None
+    file_digests: dict | None = None
 
 
 class Manifest(BaseModel):
@@ -153,7 +153,7 @@ def read_manifest() -> Manifest:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         return Manifest.model_validate(data)
-    except Exception:
+    except Exception:  # noqa: BLE001
         logger.warning("Failed to parse manifest at %s, treating as empty", path)
         return Manifest()
 
@@ -169,7 +169,7 @@ def write_manifest(manifest: Manifest) -> None:
     os.replace(tmp, target)
 
 
-def get_manifest_entry(source_uri: str) -> Optional[ManifestEntry]:
+def get_manifest_entry(source_uri: str) -> ManifestEntry | None:
     """Look up a manifest entry by source_uri. Returns None if not found."""
     manifest = read_manifest()
     for entry in manifest.models:
@@ -197,7 +197,7 @@ def remove_manifest_entry(source_uri: str) -> bool:
     return True
 
 
-def get_manifest_entry_by_slug(slug: str) -> Optional[ManifestEntry]:
+def get_manifest_entry_by_slug(slug: str) -> ManifestEntry | None:
     """Look up a manifest entry by slug. Returns None if not found."""
     manifest = read_manifest()
     for entry in manifest.models:
@@ -234,7 +234,7 @@ def delete_model_files(path: str) -> None:
 _manifest_lock = threading.Lock()
 
 
-def remove_manifest_entry_by_slug(slug: str) -> Optional[ManifestEntry]:
+def remove_manifest_entry_by_slug(slug: str) -> ManifestEntry | None:
     """Remove a manifest entry by slug under the manifest lock.
 
     Returns the removed entry (so the caller can obtain the path to delete
@@ -242,7 +242,7 @@ def remove_manifest_entry_by_slug(slug: str) -> Optional[ManifestEntry]:
     """
     with _manifest_lock:
         manifest = read_manifest()
-        removed: Optional[ManifestEntry] = None
+        removed: ManifestEntry | None = None
         new_models = []
         for entry in manifest.models:
             if entry.slug == slug and removed is None:
@@ -310,7 +310,7 @@ def _pull_harbor(
     harbor_ref: str,
     target_dir: Path,
     source_uri: str,
-) -> Optional[dict]:
+) -> dict | None:
     """Download a Harbor OCI artifact via ORAS into *target_dir*.
 
     Verifies every pulled file's sha256 against the OCI manifest layer
@@ -340,7 +340,7 @@ def _verify_pulled_digests(
     harbor_ref: str,
     target_dir: Path,
     source_uri: str,
-) -> Optional[dict]:
+) -> dict | None:
     """Verify on-disk pulled files against the OCI manifest layer digests.
 
     Uses the shared client's authenticated manifest fetch (the public
@@ -440,7 +440,7 @@ def _pull_huggingface(
     """Download a HuggingFace Hub model snapshot into *target_dir*."""
     import huggingface_hub  # type: ignore[import-untyped]
 
-    hf_token: Optional[str] = settings.hf_token or None
+    hf_token: str | None = settings.hf_token or None
 
     huggingface_hub.snapshot_download(
         repo_id=model_id,
@@ -453,15 +453,15 @@ def pull_model(
     *,
     source: str,
     source_uri: str,
-    harbor_ref: Optional[str] = None,
-    model_id: Optional[str] = None,
-    digest: Optional[str] = None,
-    size_bytes: Optional[int] = None,
-    category: Optional[str] = None,
-    name: Optional[str] = None,
-    version: Optional[str] = None,
-    checksum: Optional[str] = None,
-    metadata: Optional[dict] = None,
+    harbor_ref: str | None = None,
+    model_id: str | None = None,
+    digest: str | None = None,
+    size_bytes: int | None = None,
+    category: str | None = None,
+    name: str | None = None,
+    version: str | None = None,
+    checksum: str | None = None,
+    metadata: dict | None = None,
 ) -> dict:
     """Download a model from Harbor or HuggingFace Hub and record it in the manifest.
 
@@ -543,20 +543,19 @@ def pull_model(
                 )
 
         # 4. Validate credentials before touching the filesystem.
-        if source == "harbor":
-            if not all(
-                [
-                    settings.harbor_url,
-                    settings.harbor_username,
-                    settings.harbor_password,
-                ]
-            ):
-                raise ModelPullError(
-                    500,
-                    "credentials_missing",
-                    "Harbor credentials not configured. Set HARBOR_URL, HARBOR_USERNAME, and HARBOR_PASSWORD.",
-                    source_uri,
-                )
+        if source == "harbor" and not all(
+            [
+                settings.harbor_url,
+                settings.harbor_username,
+                settings.harbor_password,
+            ]
+        ):
+            raise ModelPullError(
+                500,
+                "credentials_missing",
+                "Harbor credentials not configured. Set HARBOR_URL, HARBOR_USERNAME, and HARBOR_PASSWORD.",
+                source_uri,
+            )
 
         # 5. Remove any stale/partial directory from a previous failed pull.
         if target_dir.exists():
@@ -565,7 +564,7 @@ def pull_model(
 
         # 6. Download — subprocess + polling allows aborting on low disk (S-018).
         # In-process mode skips the worker (used by unit tests that mock pull funcs).
-        file_digests: Optional[dict] = None
+        file_digests: dict | None = None
         try:
             if settings.pull_use_subprocess:
                 poll_s = max(0.05, settings.pull_disk_poll_interval_s)
@@ -623,7 +622,7 @@ def pull_model(
             # huggingface_hub errors (e.g. RepositoryNotFoundError) subclass OSError
             # via httpx.HTTPError; they must not be collapsed to a generic 500 here.
             _map_download_exception(exc, source_uri)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             shutil.rmtree(target_dir, ignore_errors=True)
             _map_download_exception(exc, source_uri)
 
@@ -657,7 +656,7 @@ def pull_model(
             path=str(target_dir.resolve()),
             size_bytes=size_bytes,
             digest=digest,
-            downloaded_at=datetime.now(timezone.utc).isoformat(),
+            downloaded_at=datetime.now(UTC).isoformat(),
             category=category,
             name=name,
             version=version,

--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -364,9 +364,7 @@ def _verify_pulled_digests(
 
     expected: dict[str, str] = {}
     for layer in manifest.get("layers", []):
-        title = (layer.get("annotations") or {}).get(
-            "org.opencontainers.image.title"
-        )
+        title = (layer.get("annotations") or {}).get("org.opencontainers.image.title")
         digest = layer.get("digest", "")
         if title and digest.startswith("sha256:"):
             expected[title] = digest[len("sha256:") :]
@@ -394,9 +392,7 @@ def _verify_pulled_digests(
                 harbor_ref,
             )
         elif h != want:
-            problems.append(
-                f"{path.name}: digest mismatch (got {h}, want {want})"
-            )
+            problems.append(f"{path.name}: digest mismatch (got {h}, want {want})")
     for name in expected:
         if name not in actual:
             problems.append(f"{name}: missing on disk after pull")

--- a/solar_host/process_manager.py
+++ b/solar_host/process_manager.py
@@ -1,39 +1,39 @@
 """Process manager for solar-host with multi-backend support."""
 
+import asyncio
 import logging
-import subprocess
-import socket
-import time
-import uuid
+import os
 import queue
 import shutil
-import os
-from pathlib import Path
-from datetime import datetime, timezone
-from typing import Dict, List, Optional, Any
-from collections import deque
-import asyncio
+import socket
+import subprocess
 import threading
+import time
+import uuid
+from collections import deque
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
+from solar_host.backends.base import BackendRunner
+from solar_host.backends.huggingface import HuggingFaceRunner
+from solar_host.backends.llamacpp import LlamaCppRunner
+from solar_host.config import config_manager, parse_instance_config, settings
 from solar_host.models import (
+    BackendType,
+    GenerationMetrics,
     Instance,
-    InstanceStatus,
     InstancePriority,
-    LogMessage,
     InstanceRuntimeState,
     InstanceStateEvent,
-    GenerationMetrics,
-    BackendType,
+    InstanceStatus,
+    LogMessage,
 )
-from solar_host.config import settings, config_manager, parse_instance_config
-from solar_host.backends.base import BackendRunner
-from solar_host.backends.llamacpp import LlamaCppRunner
-from solar_host.backends.huggingface import HuggingFaceRunner
 from solar_host.ws_client import (
-    get_clients,
-    broadcast_log_batch,
     broadcast_instance_state_batch,
     broadcast_instances_update,
+    broadcast_log_batch,
+    get_clients,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,28 +70,28 @@ class ProcessManager:
     """Manages model server processes across multiple backends."""
 
     def __init__(self):
-        self.processes: Dict[str, subprocess.Popen] = {}
-        self.log_buffers: Dict[str, deque] = {}
-        self.log_sequences: Dict[str, int] = {}
-        self.log_threads: Dict[str, threading.Thread] = {}
+        self.processes: dict[str, subprocess.Popen] = {}
+        self.log_buffers: dict[str, deque] = {}
+        self.log_sequences: dict[str, int] = {}
+        self.log_threads: dict[str, threading.Thread] = {}
         self.log_dir = Path(settings.log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
 
         # Runtime state streaming (ephemeral)
-        self.state_buffers: Dict[str, deque] = {}
-        self.state_sequences: Dict[str, int] = {}
+        self.state_buffers: dict[str, deque] = {}
+        self.state_sequences: dict[str, int] = {}
 
         # Per-instance parsing context (managed by backend runners)
-        self.instance_contexts: Dict[str, Dict[str, Any]] = {}
+        self.instance_contexts: dict[str, dict[str, Any]] = {}
 
         # Per-instance runner reference
-        self.instance_runners: Dict[str, BackendRunner] = {}
+        self.instance_runners: dict[str, BackendRunner] = {}
 
         # Batched emission queues (thread-safe, drained by _flush_loop).
         # Bounded to prevent OOM if the flush loop or WS broadcast stalls.
         self._log_queue: queue.Queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
         self._state_queue: queue.Queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
-        self._flush_task: Optional[asyncio.Task] = None
+        self._flush_task: asyncio.Task | None = None
         self._child_exit_lock = threading.Lock()
 
     def _is_port_available(self, port: int) -> bool:
@@ -215,7 +215,7 @@ class ProcessManager:
                     seq = self.log_sequences[instance_id]
                     self.log_sequences[instance_id] += 1
 
-                    timestamp = datetime.now(timezone.utc).isoformat()
+                    timestamp = datetime.now(UTC).isoformat()
                     log_msg = LogMessage(
                         seq=seq, timestamp=timestamp, line=decoded_line
                     )
@@ -232,10 +232,10 @@ class ProcessManager:
                         )
                         if state_update:
                             self._emit_state_event(instance_id, state_update)
-                    except Exception:
+                    except Exception:  # noqa: S110, BLE001
                         # Parsing errors should not break logging
                         pass
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("Error reading logs for %s: %s", instance_id, e)
         finally:
             # stdout closed or reader error: child likely exited — reconcile state
@@ -266,14 +266,14 @@ class ProcessManager:
 
     async def _flush_pending(self):
         """Drain both queues and emit batched events."""
-        log_entries: List[dict] = []
+        log_entries: list[dict] = []
         while True:
             try:
                 log_entries.append(self._log_queue.get_nowait())
             except queue.Empty:
                 break
 
-        latest_states: Dict[str, dict] = {}
+        latest_states: dict[str, dict] = {}
         while True:
             try:
                 entry = self._state_queue.get_nowait()
@@ -338,7 +338,7 @@ class ProcessManager:
         seq = self.state_sequences[instance_id]
         self.state_sequences[instance_id] += 1
 
-        now_ts = datetime.now(timezone.utc).isoformat()
+        now_ts = datetime.now(UTC).isoformat()
         state = InstanceRuntimeState(
             instance_id=instance_id,
             busy=update.busy,
@@ -394,7 +394,7 @@ class ProcessManager:
         except queue.Full:
             pass
 
-    def get_last_generation(self, instance_id: str) -> Optional[GenerationMetrics]:
+    def get_last_generation(self, instance_id: str) -> GenerationMetrics | None:
         """Get the last generation metrics for an instance."""
         runner = self.instance_runners.get(instance_id)
         context = self.instance_contexts.get(instance_id, {})
@@ -413,9 +413,7 @@ class ProcessManager:
             await asyncio.sleep(1)
         return False
 
-    async def _try_start_instance(
-        self, instance_id: str, attempt: int
-    ) -> Optional[bool]:
+    async def _try_start_instance(self, instance_id: str, attempt: int) -> bool | None:
         """Single start attempt. Returns True/False for final result, None to retry."""
         instance = config_manager.get_instance(instance_id)
         if not instance:
@@ -470,7 +468,7 @@ class ProcessManager:
             run_env["PYTHONUNBUFFERED"] = "1"
             run_cmd = ["stdbuf", "-oL"] + cmd if _HAS_STDBUF else cmd
 
-            process = subprocess.Popen(
+            process = subprocess.Popen(  # noqa: ASYNC220 — spawn is non-blocking; logs are drained by a dedicated thread (_read_logs), never in the event loop
                 run_cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -502,7 +500,7 @@ class ProcessManager:
             if process.poll() is None:
                 instance.status = InstanceStatus.RUNNING
                 instance.pid = process.pid
-                instance.started_at = datetime.now(timezone.utc)
+                instance.started_at = datetime.now(UTC)
                 instance.retry_count = 0
                 config_manager.update_instance(instance_id, instance)
 
@@ -529,7 +527,7 @@ class ProcessManager:
                     return None  # signal retry
                 return False
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             instance = config_manager.get_instance(instance_id)
             if instance:
                 instance.status = InstanceStatus.FAILED
@@ -594,9 +592,9 @@ class ProcessManager:
 
             return True
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             instance.status = InstanceStatus.FAILED
-            instance.error_message = f"Failed to stop: {str(e)}"
+            instance.error_message = f"Failed to stop: {e!s}"
             config_manager.update_instance(instance_id, instance)
             return False
 
@@ -609,7 +607,7 @@ class ProcessManager:
                 # Keep only the most recent log
                 if log_file.stat().st_mtime < time.time() - 300:  # 5 minutes old
                     log_file.unlink()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("Error cleaning up logs: %s", e)
 
     async def restart_instance(self, instance_id: str) -> bool:
@@ -674,7 +672,7 @@ class ProcessManager:
 
         return instance
 
-    def get_log_buffer(self, instance_id: str) -> List[LogMessage]:
+    def get_log_buffer(self, instance_id: str) -> list[LogMessage]:
         """Get log buffer for an instance."""
         if instance_id in self.log_buffers:
             return list(self.log_buffers[instance_id])
@@ -684,7 +682,7 @@ class ProcessManager:
         """Get next sequence number for an instance."""
         return self.log_sequences.get(instance_id, 0)
 
-    def get_state_buffer(self, instance_id: str) -> List[InstanceStateEvent]:
+    def get_state_buffer(self, instance_id: str) -> list[InstanceStateEvent]:
         """Get state buffer for an instance."""
         if instance_id in self.state_buffers:
             return list(self.state_buffers[instance_id])
@@ -726,7 +724,7 @@ class ProcessManager:
             try:
                 process.terminate()
                 process.wait(timeout=5)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 process.kill()
                 process.wait()
 
@@ -772,7 +770,7 @@ class ProcessManager:
                 config_manager.update_instance(instance.id, instance)
 
     @staticmethod
-    def _kill_stale_pid(pid: Optional[int]) -> None:
+    def _kill_stale_pid(pid: int | None) -> None:
         """Best-effort kill of a stale PID left from a previous run."""
         if pid is None:
             return

--- a/solar_host/resources/__init__.py
+++ b/solar_host/resources/__init__.py
@@ -1,5 +1,10 @@
 """Resource reservation primitives for Solar Host (S-034)."""
 
+from solar_host.resources.manager import (
+    CapacityExceededError,
+    ReservationRunningError,
+    ResourceManager,
+)
 from solar_host.resources.models import (
     Reservation,
     ReservationRequest,
@@ -8,20 +13,15 @@ from solar_host.resources.models import (
     ResourceSnapshot,
     WorkloadType,
 )
-from solar_host.resources.manager import (
-    CapacityExceededError,
-    ReservationRunningError,
-    ResourceManager,
-)
 
 __all__ = [
+    "CapacityExceededError",
     "Reservation",
     "ReservationRequest",
+    "ReservationRunningError",
     "ReservationView",
     "ResourceDimensionSnapshot",
+    "ResourceManager",
     "ResourceSnapshot",
     "WorkloadType",
-    "CapacityExceededError",
-    "ReservationRunningError",
-    "ResourceManager",
 ]

--- a/solar_host/resources/manager.py
+++ b/solar_host/resources/manager.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import threading
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import psutil
 
@@ -73,11 +73,11 @@ class ResourceManager:
 
     def __init__(
         self,
-        job_store: "JobStore",
-        docker_service: Optional["DockerService"],
-        job_executor: Optional["JobExecutor"],
+        job_store: JobStore,
+        docker_service: DockerService | None,
+        job_executor: JobExecutor | None,
         jobs_dir: str = "./jobs",
-        default_ttl_seconds: Optional[float] = 86400.0,
+        default_ttl_seconds: float | None = 86400.0,
     ) -> None:
         self._job_store = job_store
         self._docker_service = docker_service
@@ -225,8 +225,8 @@ class ResourceManager:
 
         mem = get_memory_info()
         memory_type = "RAM"
-        vram_dim: Optional[ResourceDimensionSnapshot] = None
-        ram_dim: Optional[ResourceDimensionSnapshot] = None
+        vram_dim: ResourceDimensionSnapshot | None = None
+        ram_dim: ResourceDimensionSnapshot | None = None
 
         if mem is not None:
             memory_type = str(mem["memory_type"])
@@ -257,7 +257,7 @@ class ResourceManager:
                         reported_used_gb=ram_reported,
                         available_gb=max(0.0, ram_total - ram_reported),
                     )
-                except Exception:
+                except Exception:  # noqa: S110, BLE001
                     pass
             else:
                 headroom = self._headroom_unlocked("ram")
@@ -270,7 +270,7 @@ class ResourceManager:
                     available_gb=max(0.0, total - reported),
                 )
 
-        disk_dim: Optional[ResourceDimensionSnapshot] = None
+        disk_dim: ResourceDimensionSnapshot | None = None
         disk_info = get_disk_info(settings.jobs_dir)
         if disk_info is not None:
             sys_disk = float(disk_info["used_gb"])

--- a/solar_host/resources/models.py
+++ b/solar_host/resources/models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -20,16 +19,16 @@ class ReservationRequest(BaseModel):
     """Input model for POST /resources/reservations."""
 
     job_id: str
-    requester: Optional[str] = None
+    requester: str | None = None
     workload_type: WorkloadType = WorkloadType.training
     vram_gb: float = Field(ge=0)
     ram_gb: float = Field(ge=0)
-    disk_gb: Optional[float] = Field(default=None, ge=0)
-    ttl_seconds: Optional[float] = Field(default=None, gt=0)
-    expires_at: Optional[datetime] = None
+    disk_gb: float | None = Field(default=None, ge=0)
+    ttl_seconds: float | None = Field(default=None, gt=0)
+    expires_at: datetime | None = None
 
     @model_validator(mode="after")
-    def _validate_expiry(self) -> "ReservationRequest":
+    def _validate_expiry(self) -> ReservationRequest:
         if self.ttl_seconds is not None and self.expires_at is not None:
             raise ValueError(
                 "Specify at most one of ttl_seconds or expires_at, not both"
@@ -42,27 +41,27 @@ class Reservation(BaseModel):
 
     id: str
     job_id: str
-    requester: Optional[str] = None
+    requester: str | None = None
     workload_type: WorkloadType
     vram_gb: float
     ram_gb: float
-    disk_gb: Optional[float] = None
+    disk_gb: float | None = None
     created_at: datetime
-    expires_at: Optional[datetime] = None
+    expires_at: datetime | None = None
 
     # Cached actual usage (updated by the poll loop for running reservations).
-    actual_vram_gb: Optional[float] = None
-    actual_ram_gb: Optional[float] = None
-    actual_disk_gb: Optional[float] = None
-    usage_polled_at: Optional[datetime] = None
+    actual_vram_gb: float | None = None
+    actual_ram_gb: float | None = None
+    actual_disk_gb: float | None = None
+    usage_polled_at: datetime | None = None
 
     @classmethod
     def from_request(
         cls,
         req: ReservationRequest,
         now: datetime,
-        default_ttl_seconds: Optional[float] = None,
-    ) -> "Reservation":
+        default_ttl_seconds: float | None = None,
+    ) -> Reservation:
         """Build a Reservation, resolving its expiry.
 
         Precedence for ``expires_at``:
@@ -72,7 +71,7 @@ class Reservation(BaseModel):
            callers that want a longer-lived reservation supply their own
            ttl_seconds/expires_at)
         """
-        expires_at: Optional[datetime] = None
+        expires_at: datetime | None = None
         if req.expires_at is not None:
             expires_at = req.expires_at
         elif req.ttl_seconds is not None:
@@ -111,18 +110,18 @@ class ReservationView(BaseModel):
     status: str  # "pending" | "running"
     vram_gb: float
     ram_gb: float
-    disk_gb: Optional[float] = None
-    actual_vram_gb: Optional[float] = None
-    actual_ram_gb: Optional[float] = None
-    actual_disk_gb: Optional[float] = None
-    expires_at: Optional[datetime] = None
+    disk_gb: float | None = None
+    actual_vram_gb: float | None = None
+    actual_ram_gb: float | None = None
+    actual_disk_gb: float | None = None
+    expires_at: datetime | None = None
 
 
 class ResourceSnapshot(BaseModel):
     """Full resource snapshot returned by GET /resources."""
 
     memory_type: str  # "VRAM" or "RAM" — primary dimension reported by get_memory_info
-    vram: Optional[ResourceDimensionSnapshot] = None
-    ram: Optional[ResourceDimensionSnapshot] = None
-    disk: Optional[ResourceDimensionSnapshot] = None
+    vram: ResourceDimensionSnapshot | None = None
+    ram: ResourceDimensionSnapshot | None = None
+    disk: ResourceDimensionSnapshot | None = None
     reservations: list[ReservationView] = []

--- a/solar_host/resources/usage.py
+++ b/solar_host/resources/usage.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from solar_host.memory_monitor import get_gpu_process_memory
 
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 async def collect_container_ram_gb(
-    docker_service: "DockerService", container_id: str
-) -> Optional[float]:
+    docker_service: DockerService, container_id: str
+) -> float | None:
     """Return RAM used by *container_id* in GB, or None on failure.
 
     Subtracts the reclaimable page cache from the raw ``memory_stats.usage``
@@ -48,14 +48,14 @@ async def collect_container_ram_gb(
             cache = stats_map.get("inactive_file") or 0
         net_bytes = max(0, usage - cache)
         return round(net_bytes / (1024**3), 4)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         logger.debug("collect_container_ram_gb(%s): %s", container_id, exc)
         return None
 
 
 async def collect_container_vram_gb(
-    docker_service: "DockerService", container_id: str
-) -> Optional[float]:
+    docker_service: DockerService, container_id: str
+) -> float | None:
     """Return GPU VRAM used by the container's host-PID tree, in GB.
 
     Steps:
@@ -82,16 +82,16 @@ async def collect_container_vram_gb(
 
         total_bytes = sum(gpu_mem.get(pid, 0) for pid in pid_set)
         return round(total_bytes / (1024**3), 4)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         logger.debug("collect_container_vram_gb(%s): %s", container_id, exc)
         return None
 
 
-async def collect_workspace_disk_gb(job_id: str, jobs_dir: str) -> Optional[float]:
+async def collect_workspace_disk_gb(job_id: str, jobs_dir: str) -> float | None:
     """Return disk usage of the job workspace directory in GB, or None."""
     try:
         return await asyncio.to_thread(_dir_size_gb, Path(jobs_dir) / job_id)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         logger.debug("collect_workspace_disk_gb(%s): %s", job_id, exc)
         return None
 
@@ -101,16 +101,14 @@ async def collect_workspace_disk_gb(job_id: str, jobs_dir: str) -> Optional[floa
 # ---------------------------------------------------------------------------
 
 
-def _get_container_pid(
-    docker_service: "DockerService", container_id: str
-) -> Optional[int]:
+def _get_container_pid(docker_service: DockerService, container_id: str) -> int | None:
     """Return the host-namespace root PID for *container_id*, or None."""
     try:
         container = docker_service._client.containers.get(container_id)
         container.reload()
         pid = container.attrs.get("State", {}).get("Pid")
         return int(pid) if pid else None
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -124,11 +122,11 @@ def _collect_pid_tree(root_pid: int) -> set[int]:
         for child in proc.children(recursive=True):
             pids.add(child.pid)
         return pids
-    except Exception:
+    except Exception:  # noqa: BLE001
         return {root_pid}
 
 
-def _dir_size_gb(path: Path) -> Optional[float]:
+def _dir_size_gb(path: Path) -> float | None:
     """Recursively sum file sizes under *path* and return GB, or None."""
     if not path.exists():
         return None

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -36,6 +36,11 @@ async def create_instance(data: InstanceCreate):
             managed_by=data.managed_by,
             intent_id=data.intent_id,
         )
+        # Push the new instance so solar-control's Redis cache learns about
+        # it immediately (flat WS shape); otherwise the gateway's HTTP poll
+        # fallback re-seeds the cache with the nested /instances shape and
+        # the reconciler's view of the instance lags (D-017).
+        process_manager._push_instances_update()
         return InstanceResponse(
             instance=instance, message=f"Instance {instance.id} created successfully"
         )

--- a/solar_host/routes/instances.py
+++ b/solar_host/routes/instances.py
@@ -1,18 +1,19 @@
-from fastapi import APIRouter, HTTPException
-from typing import List, Optional
+from datetime import UTC
 
+from fastapi import APIRouter, HTTPException
+
+from solar_host.config import config_manager, parse_instance_config
 from solar_host.models import (
+    GenerationMetrics,
     Instance,
     InstanceCreate,
-    InstanceUpdate,
-    InstanceResponse,
-    InstanceStatus,
     InstancePriority,
+    InstanceResponse,
     InstanceRuntimeState,
-    GenerationMetrics,
+    InstanceStatus,
+    InstanceUpdate,
     LogMessage,
 )
-from solar_host.config import config_manager, parse_instance_config
 from solar_host.process_manager import process_manager
 
 router = APIRouter(prefix="/instances", tags=["instances"])
@@ -44,11 +45,11 @@ async def create_instance(data: InstanceCreate):
         return InstanceResponse(
             instance=instance, message=f"Instance {instance.id} created successfully"
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("", response_model=List[Instance])
+@router.get("", response_model=list[Instance])
 async def list_instances():
     """List all instances"""
     return config_manager.get_all_instances()
@@ -100,7 +101,7 @@ async def update_instance(instance_id: str, data: InstanceUpdate):
         return InstanceResponse(
             instance=instance, message=f"Instance {instance_id} updated successfully"
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -122,7 +123,7 @@ async def delete_instance(instance_id: str):
         return InstanceResponse(
             instance=instance, message=f"Instance {instance_id} deleted successfully"
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -216,7 +217,7 @@ async def get_instance_state(instance_id: str):
     )
 
 
-@router.get("/{instance_id}/logs", response_model=List[LogMessage])
+@router.get("/{instance_id}/logs", response_model=list[LogMessage])
 async def get_instance_logs(instance_id: str):
     """Get buffered logs for an instance.
 
@@ -232,7 +233,7 @@ async def get_instance_logs(instance_id: str):
 
 @router.get("/{instance_id}/last-generation", response_model=GenerationMetrics)
 async def get_last_generation(
-    instance_id: str, after: Optional[str] = None, within_s: Optional[int] = None
+    instance_id: str, after: str | None = None, within_s: int | None = None
 ):
     """Return most recent finished generation metrics for the instance.
 
@@ -249,14 +250,12 @@ async def get_last_generation(
     if not metrics:
         raise HTTPException(status_code=404, detail="No generation metrics available")
 
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     def parse_iso(ts: str | None):
         if not ts:
             return None
-        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(
-            timezone.utc
-        )
+        return datetime.fromisoformat(ts).astimezone(UTC)
 
     finished_dt = parse_iso(metrics.finished_at)
 
@@ -274,7 +273,7 @@ async def get_last_generation(
             )
 
     if within_s is not None and within_s >= 0:
-        now_dt = datetime.now(timezone.utc)
+        now_dt = datetime.now(UTC)
         if finished_dt and (now_dt - finished_dt).total_seconds() > float(within_s):
             raise HTTPException(
                 status_code=404,

--- a/solar_host/routes/job_schemas.py
+++ b/solar_host/routes/job_schemas.py
@@ -87,7 +87,7 @@ class StepStateResponse(BaseModel):
         job_id: str,
         *,
         max_recent: int = 100,
-    ) -> "StepStateResponse":
+    ) -> StepStateResponse:
         from pathlib import Path
 
         log_file = str(Path(settings.jobs_dir) / job_id / "logs" / f"{step.name}.log")
@@ -159,7 +159,7 @@ class JobStateResponse(BaseModel):
     }
 
     @classmethod
-    def from_job_state(cls, job: JobState) -> "JobStateResponse":
+    def from_job_state(cls, job: JobState) -> JobStateResponse:
         return cls(
             job_id=job.job_id,
             name=job.name,

--- a/solar_host/routes/jobs.py
+++ b/solar_host/routes/jobs.py
@@ -168,7 +168,7 @@ async def delete_job(job_id: str, request: Request) -> dict:
     # before Docker even sends SIGKILL.
     try:
         await executor.await_job(job_id, timeout=20.0)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.warning("Timed out waiting for job %r to finish after cancel", job_id)
     except Exception:
         logger.exception(

--- a/solar_host/routes/jobs.py
+++ b/solar_host/routes/jobs.py
@@ -131,6 +131,17 @@ async def submit_job(body: JobSubmitRequest, request: Request) -> JobSubmitRespo
     )
 
 
+@router.get("", response_model=list[JobStateResponse])
+async def list_jobs(request: Request) -> list[JobStateResponse]:
+    """Return the current state of all jobs.
+
+    Consumed by solar-control's migration guard (check_no_active_training)
+    to enforce that active training jobs are non-migratable workloads.
+    """
+    store = request.app.state.job_store
+    return [JobStateResponse.from_job_state(j) for j in store.get_all()]
+
+
 @router.get("/{job_id}", response_model=JobStateResponse)
 async def get_job(job_id: str, request: Request) -> JobStateResponse:
     """Return the current state of a job, including per-step log snippets."""

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -16,7 +16,7 @@ the request with 409 if any active instance references the model. Per S-017.
 import asyncio
 import os
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
@@ -48,16 +48,16 @@ class ModelEntry(BaseModel):
     name: str
     path: str
     size_bytes: int
-    source_uri: Optional[str] = None
-    checksum: Optional[str] = None
-    downloaded_at: Optional[str] = None
-    category: Optional[str] = None
-    model_name: Optional[str] = None
-    version: Optional[str] = None
-    metadata: Optional[dict] = None
+    source_uri: str | None = None
+    checksum: str | None = None
+    downloaded_at: str | None = None
+    category: str | None = None
+    model_name: str | None = None
+    version: str | None = None
+    metadata: dict | None = None
 
 
-def _manifest_to_entries() -> List[ModelEntry]:
+def _manifest_to_entries() -> list[ModelEntry]:
     manifest = read_manifest()
     return [
         ModelEntry(
@@ -76,8 +76,8 @@ def _manifest_to_entries() -> List[ModelEntry]:
     ]
 
 
-@router.get("", response_model=List[ModelEntry], summary="List managed models")
-async def list_models() -> List[ModelEntry]:
+@router.get("", response_model=list[ModelEntry], summary="List managed models")
+async def list_models() -> list[ModelEntry]:
     """Return all models listed in the managed models manifest.
 
     Data comes only from ``manifest.json`` under ``MODELS_DIR`` (see
@@ -107,15 +107,15 @@ class PullRequest(BaseModel):
 
     source: Literal["harbor", "huggingface"]
     source_uri: str
-    harbor_ref: Optional[str] = None
-    model_id: Optional[str] = None
-    digest: Optional[str] = None
-    size_bytes: Optional[int] = None
-    category: Optional[str] = None
-    name: Optional[str] = None
-    version: Optional[str] = None
-    checksum: Optional[str] = None
-    metadata: Optional[dict] = None
+    harbor_ref: str | None = None
+    model_id: str | None = None
+    digest: str | None = None
+    size_bytes: int | None = None
+    category: str | None = None
+    name: str | None = None
+    version: str | None = None
+    checksum: str | None = None
+    metadata: dict | None = None
 
 
 class PullResponse(BaseModel):
@@ -145,7 +145,7 @@ class PullResponse(BaseModel):
         507: {"description": "Insufficient disk space"},
     },
 )
-async def pull_model(req: PullRequest) -> Union[PullResponse, JSONResponse]:
+async def pull_model(req: PullRequest) -> PullResponse | JSONResponse:
     """Pull a model from Harbor or HuggingFace Hub.
 
     Checks the manifest cache first. On a cache hit the stored path is returned
@@ -239,7 +239,7 @@ def _instance_uses_model(instance_config: object, model_dir: Path) -> bool:
     return False
 
 
-def _find_using_instance(model_dir: Path) -> Optional[str]:
+def _find_using_instance(model_dir: Path) -> str | None:
     """Return the ID of the first active instance using *model_dir*, or None."""
     for instance in config_manager.get_all_instances():
         if instance.status not in _ACTIVE_STATUSES:

--- a/solar_host/servers/hf_server.py
+++ b/solar_host/servers/hf_server.py
@@ -22,21 +22,21 @@ Usage:
 import argparse
 import base64
 import io
+import json
+import logging
 import time
 import uuid
-import logging
-from datetime import datetime, timezone
-from typing import Any, Optional, List, Dict, Union, TYPE_CHECKING
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import torch
-from fastapi import FastAPI, HTTPException, Request, Depends
-from fastapi.responses import JSONResponse
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from pydantic import BaseModel, Field
 import uvicorn
-import json
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from transformers import (
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 # Capabilities exposed via /v1/models, used by downstream apps
 # (e.g. Orchestrator) to differentiate text-only vs multimodal models.
-MODEL_TYPE_CAPABILITIES: Dict[str, List[str]] = {
+MODEL_TYPE_CAPABILITIES: dict[str, list[str]] = {
     "causal": ["completion"],
     "classification": ["classification"],
     "embedding": ["embedding"],
@@ -72,35 +72,33 @@ class ChatMessage(BaseModel):
     role: str
     # Either a plain string (text-only) or an OpenAI-style list of content parts
     # like [{"type":"text","text":"..."}, {"type":"image_url","image_url":{"url":"..."}}]
-    content: Union[str, List[Dict[str, Any]]]
-    name: Optional[str] = None
+    content: str | list[dict[str, Any]]
+    name: str | None = None
 
 
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: List[ChatMessage]
-    temperature: Optional[float] = 1.0
-    top_p: Optional[float] = 1.0
-    max_tokens: Optional[int] = None
-    stream: Optional[bool] = False
-    stop: Optional[List[str]] = None
+    messages: list[ChatMessage]
+    temperature: float | None = 1.0
+    top_p: float | None = 1.0
+    max_tokens: int | None = None
+    stream: bool | None = False
+    stop: list[str] | None = None
 
 
 class CompletionRequest(BaseModel):
     model: str
     prompt: str
-    temperature: Optional[float] = 1.0
-    top_p: Optional[float] = 1.0
-    max_tokens: Optional[int] = None
-    stream: Optional[bool] = False
-    stop: Optional[List[str]] = None
+    temperature: float | None = 1.0
+    top_p: float | None = 1.0
+    max_tokens: int | None = None
+    stream: bool | None = False
+    stop: list[str] | None = None
 
 
 class ClassifyRequest(BaseModel):
     model: str
-    input: Union[str, List[str]] = Field(
-        ..., description="Text or list of texts to classify"
-    )
+    input: str | list[str] = Field(..., description="Text or list of texts to classify")
     return_all_scores: bool = Field(
         default=False,
         description="Return scores for all classes, not just top prediction",
@@ -118,7 +116,7 @@ class ClassifyChoice(BaseModel):
     index: int
     label: str
     score: float
-    all_scores: Optional[List[ClassifyScoreItem]] = Field(
+    all_scores: list[ClassifyScoreItem] | None = Field(
         default=None, description="Scores for all classes (when return_all_scores=True)"
     )
 
@@ -127,8 +125,8 @@ class ClassifyResponse(BaseModel):
     id: str
     object: str = "classification"
     model: str
-    choices: List[ClassifyChoice]
-    usage: Dict[str, int]
+    choices: list[ClassifyChoice]
+    usage: dict[str, int]
 
 
 class ChatCompletionChoice(BaseModel):
@@ -142,8 +140,8 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int
     model: str
-    choices: List[ChatCompletionChoice]
-    usage: Dict[str, int]
+    choices: list[ChatCompletionChoice]
+    usage: dict[str, int]
 
 
 class CompletionChoice(BaseModel):
@@ -157,8 +155,8 @@ class CompletionResponse(BaseModel):
     object: str = "text_completion"
     created: int
     model: str
-    choices: List[CompletionChoice]
-    usage: Dict[str, int]
+    choices: list[CompletionChoice]
+    usage: dict[str, int]
 
 
 class ModelInfo(BaseModel):
@@ -170,28 +168,26 @@ class ModelInfo(BaseModel):
 
 class EmbeddingRequest(BaseModel):
     model: str
-    input: Union[str, List[str]] = Field(
-        ..., description="Text or list of texts to embed"
-    )
-    encoding_format: Optional[str] = Field(
+    input: str | list[str] = Field(..., description="Text or list of texts to embed")
+    encoding_format: str | None = Field(
         default="float", description="Encoding format: 'float' or 'base64'"
     )
-    dimensions: Optional[int] = Field(
+    dimensions: int | None = Field(
         default=None, description="Optional dimension truncation"
     )
 
 
 class EmbeddingData(BaseModel):
     object: str = "embedding"
-    embedding: List[float]
+    embedding: list[float]
     index: int
 
 
 class EmbeddingResponse(BaseModel):
     object: str = "list"
-    data: List[EmbeddingData]
+    data: list[EmbeddingData]
     model: str
-    usage: Dict[str, int]
+    usage: dict[str, int]
 
 
 # ============================================================================
@@ -203,22 +199,20 @@ class ServerState:
     """Global server state holding the loaded model."""
 
     def __init__(self):
-        self.model: Optional["PreTrainedModel"] = None
-        self.tokenizer: Optional[
-            Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"]
-        ] = None
+        self.model: PreTrainedModel | None = None
+        self.tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast | None = None
         # Multi-modal processor (used for vision/multimodal models). Wraps
         # the tokenizer plus image preprocessor.
-        self.processor: Optional[Any] = None
+        self.processor: Any | None = None
         self.model_id: str = ""
         self.model_type: str = "causal"
         self.alias: str = ""
         self.device: str = "cpu"
         self.max_length: int = 4096
-        self.labels: Optional[List[str]] = None
+        self.labels: list[str] | None = None
         self.normalize_embeddings: bool = True
         self.api_key: str = ""
-        self.created_at: int = int(datetime.now(timezone.utc).timestamp())
+        self.created_at: int = int(datetime.now(UTC).timestamp())
 
     def ensure_loaded(self) -> None:
         """Ensure model and tokenizer are loaded, raise if not."""
@@ -239,9 +233,7 @@ class ServerState:
     def get_dtype(self, dtype_str: str) -> torch.dtype:
         """Resolve dtype string to torch dtype."""
         if dtype_str == "auto":
-            if self.device == "cuda":
-                return torch.float16
-            elif self.device == "mps":
+            if self.device == "cuda" or self.device == "mps":
                 return torch.float16
             else:
                 return torch.float32
@@ -260,7 +252,7 @@ class ServerState:
         device: str,
         dtype: str,
         max_length: int,
-        labels: Optional[List[str]],
+        labels: list[str] | None,
         trust_remote_code: bool,
         use_flash_attention: bool,
         normalize_embeddings: bool = True,
@@ -299,7 +291,7 @@ class ServerState:
         if model_type == "causal":
             from transformers import AutoModelForCausalLM
 
-            model_kwargs: Dict[str, object] = {
+            model_kwargs: dict[str, object] = {
                 "dtype": model_dtype,
                 "trust_remote_code": trust_remote_code,
                 "device_map": self.device if self.device != "mps" else None,
@@ -363,7 +355,7 @@ class ServerState:
             )
             self.processor = processor
 
-            model_kwargs: Dict[str, object] = {
+            model_kwargs: dict[str, object] = {
                 "dtype": model_dtype,
                 "trust_remote_code": trust_remote_code,
                 "device_map": self.device if self.device != "mps" else None,
@@ -393,7 +385,7 @@ security = HTTPBearer(auto_error=False)
 
 async def verify_api_key(
     request: Request,
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ):
     """Verify API key from Authorization header."""
     if not state.api_key:
@@ -521,7 +513,7 @@ def _load_image_from_url(url: str):
 
     if url.startswith("data:"):
         try:
-            header, b64 = url.split(",", 1)
+            _header, b64 = url.split(",", 1)
         except ValueError as exc:
             raise ValueError(f"Malformed data URI: {url[:60]}...") from exc
         raw = base64.b64decode(b64)
@@ -539,23 +531,23 @@ def _load_image_from_url(url: str):
 
 
 def _normalize_messages_for_processor(
-    messages: List[ChatMessage],
-) -> tuple[List[Dict[str, Any]], List[Any]]:
+    messages: list[ChatMessage],
+) -> tuple[list[dict[str, Any]], list[Any]]:
     """Convert OpenAI-style messages into processor-friendly form + image list.
 
     Each `image_url` content part is downloaded into a PIL image and replaced
     by ``{"type": "image"}`` (the convention most multimodal HF processors expect
     for ``apply_chat_template``).
     """
-    norm_messages: List[Dict[str, Any]] = []
-    images: List[Any] = []
+    norm_messages: list[dict[str, Any]] = []
+    images: list[Any] = []
 
     for m in messages:
         if isinstance(m.content, str):
             norm_messages.append({"role": m.role, "content": m.content})
             continue
 
-        parts: List[Dict[str, Any]] = []
+        parts: list[dict[str, Any]] = []
         for part in m.content:
             ptype = part.get("type")
             if ptype == "text":
@@ -587,7 +579,7 @@ async def _chat_completion_causal(
     logger.info(f"[REQUEST] model={state.alias} endpoint=/v1/chat/completions")
 
     # Causal text-only path expects plain string content.
-    plain_messages: List[Dict[str, str]] = []
+    plain_messages: list[dict[str, str]] = []
     for m in request.messages:
         if not isinstance(m.content, str):
             raise HTTPException(
@@ -684,7 +676,7 @@ async def _chat_completion_vision(
     )
     prompt = str(template_result)
 
-    proc_kwargs: Dict[str, Any] = {
+    proc_kwargs: dict[str, Any] = {
         "text": prompt,
         "return_tensors": "pt",
     }
@@ -765,8 +757,8 @@ async def chat_completions(
         return await _chat_completion_causal(request)
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"[ERROR] {str(e)}")
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[ERROR] {e!s}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -841,8 +833,8 @@ async def completions(request: CompletionRequest, _: bool = Depends(verify_api_k
             },
         )
 
-    except Exception as e:
-        logger.error(f"[ERROR] {str(e)}")
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[ERROR] {e!s}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -866,7 +858,7 @@ async def classify(request: ClassifyRequest, _: bool = Depends(verify_api_key)):
 
     try:
         # Handle single or batch input
-        texts: List[str] = (
+        texts: list[str] = (
             request.input if isinstance(request.input, list) else [request.input]
         )
 
@@ -902,7 +894,7 @@ async def classify(request: ClassifyRequest, _: bool = Depends(verify_api_key)):
                 label = state.labels[best_idx]
 
             # Build all_scores if requested
-            all_scores: Optional[List[ClassifyScoreItem]] = None
+            all_scores: list[ClassifyScoreItem] | None = None
             if request.return_all_scores:
                 all_scores = []
                 for class_idx in range(prob.shape[0]):
@@ -940,8 +932,8 @@ async def classify(request: ClassifyRequest, _: bool = Depends(verify_api_key)):
             },
         )
 
-    except Exception as e:
-        logger.error(f"[ERROR] {str(e)}")
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[ERROR] {e!s}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -969,7 +961,7 @@ async def embeddings(request: EmbeddingRequest, _: bool = Depends(verify_api_key
 
     try:
         # Handle single or batch input
-        texts: List[str] = (
+        texts: list[str] = (
             request.input if isinstance(request.input, list) else [request.input]
         )
 
@@ -1040,8 +1032,8 @@ async def embeddings(request: EmbeddingRequest, _: bool = Depends(verify_api_key
             },
         )
 
-    except Exception as e:
-        logger.error(f"[ERROR] {str(e)}")
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[ERROR] {e!s}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -10,8 +10,8 @@ handling:
 import asyncio
 import logging
 import ssl
-from datetime import datetime, timezone
-from typing import Optional, Dict, Any, List
+from datetime import UTC, datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def _to_http_url(ws_url: str) -> str:
         url = "https://" + url[6:]
     elif url.startswith("ws://"):
         url = "http://" + url[5:]
-    elif not (url.startswith("http://") or url.startswith("https://")):
+    elif not (url.startswith(("http://", "https://"))):
         url = "http://" + url
 
     parsed = urlparse(url)
@@ -71,14 +71,14 @@ class SolarControlClient:
         self.insecure = insecure
 
         # Host ID assigned by solar-control after registration_ack
-        self.host_id: Optional[str] = None
+        self.host_id: str | None = None
 
-        self._sio: Optional["socketio.AsyncClient"] = None
+        self._sio: socketio.AsyncClient | None = None
         self._connected = False
         self._pending = False
         self._running = False
-        self._connection_task: Optional[Any] = None
-        self._registration_task: Optional[asyncio.Task] = None
+        self._connection_task: Any | None = None
+        self._registration_task: asyncio.Task | None = None
 
     @property
     def is_connected(self) -> bool:
@@ -118,7 +118,7 @@ class SolarControlClient:
         if self._sio:
             try:
                 await self._sio.disconnect()
-            except Exception:
+            except Exception:  # noqa: S110, BLE001
                 pass
             self._sio = None
 
@@ -193,7 +193,7 @@ class SolarControlClient:
                 await sio.wait()
             except asyncio.CancelledError:
                 break
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 if self._running:
                     logger.warning("SolarControlClient: Connection error: %s", e)
                     await asyncio.sleep(outer_backoff)
@@ -329,14 +329,14 @@ class SolarControlClient:
             return
         try:
             await self._sio.emit(event, data, namespace=self.NAMESPACE)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("SolarControlClient: Emit error: %s", e)
 
-    async def send_log_batch(self, entries: List[dict]):
+    async def send_log_batch(self, entries: list[dict]):
         """Send a batch of log messages to solar-control in a single emit."""
         await self._emit("log_batch", {"entries": entries})
 
-    async def send_step_log_batch(self, entries: List[dict]) -> None:
+    async def send_step_log_batch(self, entries: list[dict]) -> None:
         """Send a batch of step log lines to solar-control in a single emit."""
         await self._emit("step_log", {"entries": entries})
 
@@ -344,14 +344,14 @@ class SolarControlClient:
         """Emit a job lifecycle event directly by name (fire-and-forget)."""
         await self._emit(event_name, data)
 
-    async def send_instance_state_batch(self, entries: List[dict]):
+    async def send_instance_state_batch(self, entries: list[dict]):
         """Send a batch of instance state updates to solar-control."""
         await self._emit("instance_state_batch", {"entries": entries})
 
     async def send_health(
         self,
-        memory: Optional[Dict[str, Any]] = None,
-        resource_manager: Optional[Any] = None,
+        memory: dict[str, Any] | None = None,
+        resource_manager: Any | None = None,
     ):
         """Send host health/memory update to solar-control.
 
@@ -360,12 +360,12 @@ class SolarControlClient:
         added to the health payload (per-dimension totals + active count only —
         no per-reservation list, per decision O4).
         """
+        from solar_host.config import config_manager, settings
         from solar_host.memory_monitor import (
-            get_memory_info,
             detect_gpu_type,
             get_disk_info,
+            get_memory_info,
         )
-        from solar_host.config import config_manager, settings
 
         if memory is None:
             memory = await asyncio.to_thread(get_memory_info)
@@ -377,7 +377,7 @@ class SolarControlClient:
 
         from solar_host import __version__
 
-        health_data: Dict[str, Any] = {
+        health_data: dict[str, Any] = {
             "memory": memory,
             "gpu_type": gpu_type,
             "roles": config_manager.roles,
@@ -395,7 +395,7 @@ class SolarControlClient:
         if resource_manager is not None:
             try:
                 snap = await asyncio.to_thread(resource_manager.snapshot)
-                reservations_block: Dict[str, Any] = {
+                reservations_block: dict[str, Any] = {
                     "active_count": len(snap.reservations),
                 }
                 for dim_name, dim in (
@@ -412,13 +412,13 @@ class SolarControlClient:
                             "available_gb": dim.available_gb,
                         }
                 health_data["reservations"] = reservations_block
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 logger.warning("send_health: failed to include reservations: %s", exc)
 
         await self._emit(
             "host_health",
             {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "data": health_data,
             },
         )
@@ -454,7 +454,7 @@ class SolarControlClient:
         await self._emit(
             "instances_update",
             {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "data": {"instances": instances},
             },
         )
@@ -487,15 +487,15 @@ if HAS_SOCKETIO and socketio is not None:
 
 
 # Global client instances (initialized in main.py)
-solar_control_clients: List[SolarControlClient] = []
+solar_control_clients: list[SolarControlClient] = []
 
 
-def get_clients() -> List[SolarControlClient]:
+def get_clients() -> list[SolarControlClient]:
     """Get all solar-control clients."""
     return solar_control_clients
 
 
-def get_client() -> Optional[SolarControlClient]:
+def get_client() -> SolarControlClient | None:
     """Get the first connected solar-control client (legacy compatibility)."""
     for client in solar_control_clients:
         if client.is_connected:
@@ -503,7 +503,7 @@ def get_client() -> Optional[SolarControlClient]:
     return solar_control_clients[0] if solar_control_clients else None
 
 
-def init_clients(settings) -> List[SolarControlClient]:
+def init_clients(settings) -> list[SolarControlClient]:
     """Initialize solar-control client from settings.
 
     Uses single URL (first if multiple configured) - connect to load balancer.
@@ -535,14 +535,14 @@ def init_clients(settings) -> List[SolarControlClient]:
     return solar_control_clients
 
 
-async def broadcast_log_batch(entries: List[dict]):
+async def broadcast_log_batch(entries: list[dict]):
     """Send a batch of log messages to solar-control."""
     client = get_client()
     if client:
         await client.send_log_batch(entries)
 
 
-async def broadcast_step_log_batch(entries: List[dict]) -> None:
+async def broadcast_step_log_batch(entries: list[dict]) -> None:
     """Send a batch of step log lines to solar-control."""
     client = get_client()
     if client:
@@ -556,7 +556,7 @@ async def broadcast_job_lifecycle(event_name: str, data: dict) -> None:
         await client.send_job_lifecycle(event_name, data)
 
 
-async def broadcast_instance_state_batch(entries: List[dict]):
+async def broadcast_instance_state_batch(entries: list[dict]):
     """Send a batch of instance state updates to solar-control."""
     client = get_client()
     if client:
@@ -564,8 +564,8 @@ async def broadcast_instance_state_batch(entries: List[dict]):
 
 
 async def broadcast_health(
-    memory: Optional[Dict[str, Any]] = None,
-    resource_manager: Optional[Any] = None,
+    memory: dict[str, Any] | None = None,
+    resource_manager: Any | None = None,
 ):
     """Send health update to solar-control."""
     client = get_client()

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -228,7 +228,6 @@ class SolarControlClient:
         If we were pending, this means the admin just approved us --
         re-send registration + health so solar-control has fresh data.
         """
-        was_pending = self._pending
         self._pending = False
         self.host_id = data.get("host_id")
         host_name = data.get("host_name", self.host_id)

--- a/solar_host/ws_client.py
+++ b/solar_host/ws_client.py
@@ -235,8 +235,12 @@ class SolarControlClient:
         logger.info(
             "SolarControlClient: Registered as '%s' (id: %s)", host_name, self.host_id
         )
-        if was_pending:
-            asyncio.create_task(self._post_approval_sync())
+        # Re-send registration + health after approval regardless of the
+        # pending state. The initial _send_registration from _on_connect is
+        # swallowed by the `connected` guard (the attribute flips only after
+        # connect() returns), so pre-registered hosts would otherwise NEVER
+        # deliver roles/gpu_type/instances to solar-control.
+        asyncio.create_task(self._post_approval_sync())
 
     def _on_pending(self, data: dict):
         """Handle pending event - host is waiting for admin approval."""
@@ -262,7 +266,13 @@ class SolarControlClient:
 
     async def _send_registration(self):
         """Send registration event with instance list."""
-        if not self._sio or not self._sio.connected:
+        # NOTE: guard on self._connected (namespace-level flag set in
+        # _on_connect), NOT on self._sio.connected — that transport flag
+        # only flips after connect() returns, while _on_connect (and the
+        # registration_ack event) fire BEFORE that, so a `sio.connected`
+        # guard silently swallows the only registration ever sent for
+        # pre-registered hosts.
+        if not self._sio or not self._connected:
             return
 
         from solar_host.config import config_manager
@@ -316,7 +326,7 @@ class SolarControlClient:
 
     async def _emit(self, event: str, data: dict):
         """Emit event to solar-control (no-op if disconnected)."""
-        if not self._sio or not self._sio.connected:
+        if not self._sio or not self._connected:
             return
         try:
             await self._sio.emit(event, data, namespace=self.NAMESPACE)

--- a/tests/test_docker_service.py
+++ b/tests/test_docker_service.py
@@ -45,12 +45,14 @@ def _make_service(mock_client: MagicMock) -> DockerService:
 
 
 def test_daemon_unavailable_raises():
-    with patch(
-        "solar_host.docker.service.docker.from_env",
-        side_effect=_docker_errors.DockerException("daemon down"),
+    with (
+        patch(
+            "solar_host.docker.service.docker.from_env",
+            side_effect=_docker_errors.DockerException("daemon down"),
+        ),
+        pytest.raises(DaemonUnavailableError),
     ):
-        with pytest.raises(DaemonUnavailableError):
-            DockerService(settings=_TEST_SETTINGS)
+        DockerService(settings=_TEST_SETTINGS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_instance_priority.py
+++ b/tests/test_instance_priority.py
@@ -4,9 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from solar_host.models.base import (
-    InstancePriority,
     Instance,
     InstanceCreate,
+    InstancePriority,
     InstanceUpdate,
 )
 

--- a/tests/test_job_executor.py
+++ b/tests/test_job_executor.py
@@ -196,9 +196,9 @@ async def test_insufficient_disk_raises_and_fails_job() -> None:
         patch(f"{_EXECUTOR_MODULE}.check_disk_space", side_effect=[None, disk_error]),
         patch(f"{_EXECUTOR_MODULE}.create_workspace", return_value=_WORKSPACE),
         _WORKSPACE_PATCHES[3],
+        pytest.raises(InsufficientDiskError),
     ):
-        with pytest.raises(InsufficientDiskError):
-            await executor.run_job(job_def)
+        await executor.run_job(job_def)
 
     assert store.get(job_def.job_id).status == JobStatus.failed  # type: ignore[union-attr]
 

--- a/tests/test_job_models.py
+++ b/tests/test_job_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -81,7 +81,7 @@ def test_step_definition_with_gpu_options():
 
 
 def test_step_definition_missing_required_raises():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         StepDefinition(name="train")  # type: ignore[call-arg]
 
 
@@ -218,8 +218,8 @@ def test_step_state_defaults():
 
 
 def test_step_state_with_all_fields():
-    now = datetime(2024, 1, 1, 12, 0, 0)
-    later = datetime(2024, 1, 1, 12, 5, 0)
+    now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    later = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
     state = StepState(
         name="train",
         status=StepStatus.completed,

--- a/tests/test_job_step_executor.py
+++ b/tests/test_job_step_executor.py
@@ -179,7 +179,7 @@ async def test_container_start_error_returns_true_and_marks_step_failed() -> Non
 
 @pytest.mark.anyio
 async def test_remove_container_called_even_on_nonzero_exit() -> None:
-    step_exec, ds, store = _make_step_executor()
+    step_exec, ds, _store = _make_step_executor()
     ds.wait_container.side_effect = ContainerNonZeroExitError("container-xyz", 1, [])
 
     with patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"):
@@ -196,7 +196,7 @@ async def test_remove_container_called_even_on_nonzero_exit() -> None:
 @pytest.mark.anyio
 async def test_active_container_cleared_after_step() -> None:
     active: dict[str, str] = {}
-    step_exec, ds, store = _make_step_executor(active_containers=active)
+    step_exec, _ds, _store = _make_step_executor(active_containers=active)
 
     with patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"):
         await step_exec.run(_JOB_ID, 0, _make_step(), _WORKSPACE)
@@ -323,9 +323,11 @@ def test_validate_gpu_options_valid_count() -> None:
 
 def test_validate_gpu_options_count_exceeds_inventory_raises() -> None:
     step_exec, _, _ = _make_step_executor()
-    with patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=_TWO_GPU_INVENTORY):
-        with pytest.raises(GpuValidationError):
-            step_exec._validate_gpu_options(GpuOptions(count=5))
+    with (
+        patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=_TWO_GPU_INVENTORY),
+        pytest.raises(GpuValidationError),
+    ):
+        step_exec._validate_gpu_options(GpuOptions(count=5))
 
 
 def test_validate_gpu_options_count_minus_one_skips_count_check() -> None:
@@ -352,9 +354,11 @@ def test_validate_gpu_options_valid_device_uuid() -> None:
 
 def test_validate_gpu_options_invalid_device_id_raises() -> None:
     step_exec, _, _ = _make_step_executor()
-    with patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=_TWO_GPU_INVENTORY):
-        with pytest.raises(GpuValidationError):
-            step_exec._validate_gpu_options(GpuOptions(device_ids=["99"]))
+    with (
+        patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=_TWO_GPU_INVENTORY),
+        pytest.raises(GpuValidationError),
+    ):
+        step_exec._validate_gpu_options(GpuOptions(device_ids=["99"]))
 
 
 def test_validate_gpu_options_empty_inventory_skips() -> None:
@@ -377,9 +381,11 @@ async def test_gpu_unavailable_error_marks_step_failed() -> None:
     step_exec, ds, _ = _make_step_executor(store=store)
     ds.create_container.side_effect = GpuUnavailableError("toolkit missing")
 
-    with patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=[]):
-        with patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"):
-            result = await step_exec.run(_JOB_ID, 0, step, _WORKSPACE)
+    with (
+        patch(f"{_STEP_MODULE}.get_gpu_devices", return_value=[]),
+        patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"),
+    ):
+        result = await step_exec.run(_JOB_ID, 0, step, _WORKSPACE)
 
     assert result is True
     assert store.get(_JOB_ID).steps[0].status == StepStatus.failed  # type: ignore[union-attr]
@@ -477,12 +483,14 @@ def test_stream_logs_failure_does_not_raise(tmp_path: Path) -> None:
 
 @pytest.mark.anyio
 async def test_mark_completed_called_on_success() -> None:
-    step_exec, ds, _ = _make_step_executor()
+    step_exec, _ds, _ = _make_step_executor()
     mock_buf = MagicMock()
 
-    with patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"):
-        with patch(_BUF_MODULE, mock_buf):
-            await step_exec.run(_JOB_ID, 0, _make_step(), _WORKSPACE)
+    with (
+        patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"),
+        patch(_BUF_MODULE, mock_buf),
+    ):
+        await step_exec.run(_JOB_ID, 0, _make_step(), _WORKSPACE)
 
     mock_buf.mark_completed.assert_called_once_with(_JOB_ID, "train", 0, exit_code=0)
 
@@ -493,9 +501,11 @@ async def test_mark_completed_called_on_nonzero_exit() -> None:
     ds.wait_container.side_effect = ContainerNonZeroExitError("ctr", 5, [])
     mock_buf = MagicMock()
 
-    with patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"):
-        with patch(_BUF_MODULE, mock_buf):
-            await step_exec.run(_JOB_ID, 0, _make_step(), _WORKSPACE)
+    with (
+        patch(f"{_STEP_MODULE}.JobStepExecutor._stream_logs"),
+        patch(_BUF_MODULE, mock_buf),
+    ):
+        await step_exec.run(_JOB_ID, 0, _make_step(), _WORKSPACE)
 
     mock_buf.mark_completed.assert_called_once_with(_JOB_ID, "train", 0, exit_code=5)
 

--- a/tests/test_model_source_resolution.py
+++ b/tests/test_model_source_resolution.py
@@ -1,10 +1,12 @@
 """Tests for model source URI resolution and instance configuration parsing."""
 
-import pytest
 from pathlib import Path
-from solar_host.config import resolve_model_source, parse_instance_config
-from solar_host.models.llamacpp import LlamaCppConfig
+
+import pytest
+
+from solar_host.config import parse_instance_config, resolve_model_source
 from solar_host.models.huggingface import HuggingFaceCausalConfig
+from solar_host.models.llamacpp import LlamaCppConfig
 
 
 @pytest.fixture

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -4,6 +4,7 @@ All external I/O (Harbor OrasHelper, huggingface_hub.snapshot_download) is
 mocked. Filesystem operations use tmp_path so nothing touches the real disk.
 """
 
+import hashlib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -324,6 +325,192 @@ class TestCacheHit:
         assert data["cached"] is False
         assert data["path"] == str((slug_dir / "other.gguf").resolve())
         mock_pull.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Post-pull digest verification (D-017)
+# ---------------------------------------------------------------------------
+
+
+class _FakeOras:
+    """Minimal OrasHelper stand-in: ``_client.get_manifest`` returns layers."""
+
+    def __init__(self, file_digests: dict[str, str], *, fail_manifest: bool = False):
+        self._client = _FakeOrasClient(file_digests, fail_manifest=fail_manifest)
+
+
+class _FakeOrasClient:
+    def __init__(self, file_digests: dict[str, str], *, fail_manifest: bool):
+        self._file_digests = file_digests
+        self._fail_manifest = fail_manifest
+
+    def get_manifest(self, harbor_ref: str) -> dict:
+        if self._fail_manifest:
+            raise RuntimeError("registry unreachable")
+        return {
+            "layers": [
+                {
+                    "digest": f"sha256:{digest}",
+                    "annotations": {
+                        "org.opencontainers.image.title": name
+                    },
+                }
+                for name, digest in self._file_digests.items()
+            ]
+        }
+
+
+class TestDigestVerification:
+    """Pulled artifacts are verified against OCI manifest layer digests."""
+
+    def _artifact_dir(self, _isolated_env: Path) -> Path:
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        return slug_dir
+
+    def test_verify_pulled_digests_happy_path(self, _isolated_env: Path):
+        from solar_host.models_manager import _verify_pulled_digests
+
+        slug_dir = self._artifact_dir(_isolated_env)
+        data = b"x" * 1024
+        (slug_dir / "model.gguf").write_bytes(data)
+        want = hashlib.sha256(data).hexdigest()
+
+        digests = _verify_pulled_digests(
+            _FakeOras({"model.gguf": want}),
+            "imgrepo.damit.hu/supernova/iris-osl:v3",
+            slug_dir,
+            "repo://iris-osl:v3",
+        )
+        assert digests == {"model.gguf": want}
+
+    def test_verify_pulled_digests_detects_tamper(self, _isolated_env: Path):
+        from solar_host.models_manager import ModelPullError, _verify_pulled_digests
+
+        slug_dir = self._artifact_dir(_isolated_env)
+        (slug_dir / "model.gguf").write_bytes(b"y" * 1024)  # tampered
+        want = hashlib.sha256(b"x" * 1024).hexdigest()
+
+        with pytest.raises(ModelPullError) as ei:
+            _verify_pulled_digests(
+                _FakeOras({"model.gguf": want}),
+                "imgrepo.damit.hu/supernova/iris-osl:v3",
+                slug_dir,
+                "repo://iris-osl:v3",
+            )
+        assert "integrity check failed" in str(ei.value)
+        assert "model.gguf" in str(ei.value)
+
+    def test_verify_pulled_digests_detects_missing_file(self, _isolated_env: Path):
+        from solar_host.models_manager import ModelPullError, _verify_pulled_digests
+
+        slug_dir = self._artifact_dir(_isolated_env)  # empty
+        want = hashlib.sha256(b"x" * 1024).hexdigest()
+
+        with pytest.raises(ModelPullError) as ei:
+            _verify_pulled_digests(
+                _FakeOras({"model.gguf": want}),
+                "imgrepo.damit.hu/supernova/iris-osl:v3",
+                slug_dir,
+                "repo://iris-osl:v3",
+            )
+        assert "model.gguf: missing on disk" in str(ei.value)
+
+    def test_verify_pulled_digests_skips_when_manifest_unavailable(
+        self, _isolated_env: Path
+    ):
+        from solar_host.models_manager import _verify_pulled_digests
+
+        slug_dir = self._artifact_dir(_isolated_env)
+        (slug_dir / "model.gguf").write_bytes(b"x" * 1024)
+
+        digests = _verify_pulled_digests(
+            _FakeOras({}, fail_manifest=True),
+            "imgrepo.damit.hu/supernova/iris-osl:v3",
+            slug_dir,
+            "repo://iris-osl:v3",
+        )
+        assert digests is None
+
+    def test_cache_hit_with_matching_digests_returns_cached(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        slug_dir = self._artifact_dir(_isolated_env)
+        data = b"x" * 1024
+        (slug_dir / "model.gguf").write_bytes(data)
+        entry = _make_manifest_entry(path=str(slug_dir.resolve()))
+        entry.file_digests = {"model.gguf": hashlib.sha256(data).hexdigest()}
+        add_manifest_entry(entry)
+
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is True
+        mock_pull.assert_not_called()
+
+    def test_cache_hit_with_corrupt_file_re_pulls(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Corrupt cached artifact -> digest check fires -> re-pull."""
+        ensure_models_dir()
+        slug_dir = self._artifact_dir(_isolated_env)
+        (slug_dir / "model.gguf").write_bytes(b"corrupt!")
+        entry = _make_manifest_entry(path=str(slug_dir.resolve()))
+        entry.file_digests = {"model.gguf": hashlib.sha256(b"original").hexdigest()}
+        add_manifest_entry(entry)
+
+        def _recreate(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "model.gguf").write_bytes(b"x" * 1024)
+
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=_recreate,
+        ) as mock_pull:
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is False
+        mock_pull.assert_called_once()
+
+    def test_cache_hit_without_digests_still_cached(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """Pre-D-017 entries (no file_digests) keep the legacy cache behavior."""
+        ensure_models_dir()
+        slug_dir = self._artifact_dir(_isolated_env)
+        (slug_dir / "model.gguf").write_bytes(b"x" * 1024)
+        add_manifest_entry(_make_manifest_entry(path=str(slug_dir.resolve())))
+
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is True
+        mock_pull.assert_not_called()
+
+    def test_pull_records_file_digests_in_manifest(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        def _pull_with_digests(harbor_ref, target_dir, source_uri):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            data = b"x" * 1024
+            (target_dir / "model.gguf").write_bytes(data)
+            return {"model.gguf": hashlib.sha256(data).hexdigest()}
+
+        with patch(
+            "solar_host.models_manager._pull_harbor", side_effect=_pull_with_digests
+        ):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+        assert resp.status_code == 200
+
+        entry = get_manifest_entry("repo://iris-osl:v3")
+        assert entry is not None
+        assert entry.file_digests == {
+            "model.gguf": hashlib.sha256(b"x" * 1024).hexdigest()
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -351,9 +351,7 @@ class _FakeOrasClient:
             "layers": [
                 {
                     "digest": f"sha256:{digest}",
-                    "annotations": {
-                        "org.opencontainers.image.title": name
-                    },
+                    "annotations": {"org.opencontainers.image.title": name},
                 }
                 for name, digest in self._file_digests.items()
             ]

--- a/tests/test_resources_routes.py
+++ b/tests/test_resources_routes.py
@@ -109,10 +109,12 @@ def manager(store: JobStore, tmp_path: Path) -> ResourceManager:
 
 @pytest.fixture()
 def client(manager: ResourceManager):
-    with patch("solar_host.docker.service.DockerService"):
-        with TestClient(app, raise_server_exceptions=True) as c:
-            app.state.resource_manager = manager
-            yield c
+    with (
+        patch("solar_host.docker.service.DockerService"),
+        TestClient(app, raise_server_exceptions=True) as c,
+    ):
+        app.state.resource_manager = manager
+        yield c
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_jobs.py
+++ b/tests/test_routes_jobs.py
@@ -31,17 +31,17 @@ def _make_job_state(
     **overrides,
 ) -> JobState:
     now = datetime.now(UTC)
-    defaults: dict = dict(
-        job_id=job_id,
-        name="Test Job",
-        status=status,
-        steps=[StepState(name="step1")],
-        current_step_index=-1,
-        workspace_path=f"/tmp/solar-jobs/{job_id}",
-        created_at=now,
-        started_at=now,
-        retention_hours=24.0,
-    )
+    defaults: dict = {
+        "job_id": job_id,
+        "name": "Test Job",
+        "status": status,
+        "steps": [StepState(name="step1")],
+        "current_step_index": -1,
+        "workspace_path": f"/tmp/solar-jobs/{job_id}",
+        "created_at": now,
+        "started_at": now,
+        "retention_hours": 24.0,
+    }
     defaults.update(overrides)
     return JobState(**defaults)
 
@@ -89,11 +89,13 @@ def mock_executor() -> MagicMock:
 def client(mock_executor: MagicMock, mock_store: JobStore):
     """Full-lifespan TestClient with DockerService patched out and app state
     replaced with fresh mocks so each test is fully isolated."""
-    with patch("solar_host.docker.service.DockerService"):
-        with TestClient(app, raise_server_exceptions=True) as c:
-            app.state.job_executor = mock_executor
-            app.state.job_store = mock_store
-            yield c
+    with (
+        patch("solar_host.docker.service.DockerService"),
+        TestClient(app, raise_server_exceptions=True) as c,
+    ):
+        app.state.job_executor = mock_executor
+        app.state.job_store = mock_store
+        yield c
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -116,9 +116,11 @@ def test_check_disk_space_sufficient(tmp_path: Path):
 
 def test_check_disk_space_insufficient(tmp_path: Path):
     # 1 GB free, 2 GB required — must raise
-    with patch("shutil.disk_usage", return_value=_fake_disk_usage(1 * 1024**3)):
-        with pytest.raises(InsufficientDiskError) as exc_info:
-            check_disk_space(tmp_path, min_free_gb=2.0)
+    with (
+        patch("shutil.disk_usage", return_value=_fake_disk_usage(1 * 1024**3)),
+        pytest.raises(InsufficientDiskError) as exc_info,
+    ):
+        check_disk_space(tmp_path, min_free_gb=2.0)
     err = exc_info.value
     assert err.required_gb == 2.0
     assert err.available_gb == pytest.approx(1.0, abs=0.01)
@@ -133,9 +135,11 @@ def test_check_disk_space_exactly_at_threshold(tmp_path: Path):
 def test_check_disk_space_just_below_threshold(tmp_path: Path):
     # 1 byte below 2 GB — must raise
     slightly_below = 2 * 1024**3 - 1
-    with patch("shutil.disk_usage", return_value=_fake_disk_usage(slightly_below)):
-        with pytest.raises(InsufficientDiskError):
-            check_disk_space(tmp_path, min_free_gb=2.0)
+    with (
+        patch("shutil.disk_usage", return_value=_fake_disk_usage(slightly_below)),
+        pytest.raises(InsufficientDiskError),
+    ):
+        check_disk_space(tmp_path, min_free_gb=2.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
D-017 host-side fixes required by the end-to-end `repo://` integration test and its live verification on the dev hosts.

Fixes the WS registration path (pre-registered hosts never delivered roles/gpu_type/instances to solar-control because the registration was swallowed by a transport-level `connected` guard), pushes `instances_update` after instance creation so solar-control's Redis cache learns about new instances immediately, adds the `GET /jobs` list route consumed by solar-control's migration guard, and implements post-pull digest verification so corrupt cached artifacts are detected and re-pulled instead of crashing every restart-in-place RECREATE.

## Changes
- **`ws_client.py`**: registration + health re-sent after approval regardless of pending state; `_send_registration`/`_emit` guard on `_connected` (namespace flag) instead of `_sio.connected` (transport flag that only flips after `connect()` returns — swallowing the only registration for pre-registered hosts)
- **`routes/instances.py`**: push `instances_update` after instance create so solar-control's gateway cache sees the flat WS shape immediately (avoids poll-fallback re-seed lag)
- **`routes/jobs.py`**: new `GET /jobs` list route — consumed by solar-control's `check_no_active_training` migration guard
- **`models_manager.py`**: per-file sha256 (`file_digests`) recorded in the cache manifest at pull time, verified against OCI manifest layer digests; verified on every cache hit — missing/corrupt files trigger re-pull; pre-D-017 entries (no digests) keep legacy behavior
- **Tests** (`tests/test_pull.py`): digest verification coverage — happy path, tamper detection, missing-file detection, manifest-unavailable skip, corrupt-cache re-pull, legacy-entry cache hit

## Related Issues
Tied to DamitDev/solar-control#44
