### PR TITLE
fix(models): auto-select largest gguf for llama.cpp repo:// pulls

### DIFF
--- a/solar_host/models_manager.py
+++ b/solar_host/models_manager.py
@@ -138,6 +138,23 @@ def repo_base_uri(uri: str) -> str:
     return uri
 
 
+def _select_gguf_path(model_dir: Path) -> Path | None:
+    """Return the largest ``*.gguf`` at the root of *model_dir*, or None.
+
+    Used for llama.cpp + ``repo://`` artifacts: llama-server needs a file,
+    and when the artifact carries multiple GGUFs (e.g. quantised variants)
+    the largest one is the definitive model.  Subdirectories are not
+    scanned — ORAS pulls are flat and an explicit subpath already exists
+    for nested files.
+    """
+    candidates = [
+        p for p in model_dir.glob("*.gguf") if p.is_file() and not p.is_symlink()
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_size)
+
+
 def _manifest_path() -> Path:
     return get_models_dir() / MANIFEST_FILENAME
 
@@ -462,6 +479,7 @@ def pull_model(
     version: str | None = None,
     checksum: str | None = None,
     metadata: dict | None = None,
+    backend_type: str | None = None,
 ) -> dict:
     """Download a model from Harbor or HuggingFace Hub and record it in the manifest.
 
@@ -470,6 +488,14 @@ def pull_model(
 
     Returns a dict with keys ``path``, ``cached``, and ``source_uri``.
     Raises ``ModelPullError`` for all expected failure conditions.
+
+    GGUF selection: when the caller declares a llama.cpp backend
+    (``backend_type == "llamacpp"``) and the artifact comes from Harbor
+    (``repo://``), the returned path resolves to the largest ``*.gguf``
+    inside the artifact directory instead of the directory itself — a
+    llama-server model must be a file. An explicit subpath in the URI wins
+    over selection. ``local://`` and ``huggingface://`` artifacts are never
+    selected (they are used as directories).
     """
     # 1. Validate that source_uri scheme matches the declared source.
     expected_prefix = _SOURCE_URI_PREFIXES.get(source)
@@ -496,6 +522,12 @@ def pull_model(
         subpath = extract_repo_subpath(source_uri)
         cache_key = repo_base_uri(source_uri)
 
+        # 2b. GGUF selection for llama.cpp + Harbor artifacts: the returned
+        #     path points at the largest *.gguf inside the artifact directory
+        #     instead of the directory (llama-server needs a file).  An
+        #     explicit subpath always wins over selection.
+        select_gguf = source == "harbor" and backend_type == "llamacpp" and not subpath
+
         # 2. Cache check — manifest is the single source of truth, keyed by
         #    the base URI (the artifact identity).  Verify the resolved path
         #    (dir + optional subpath) still exists on disk AND the recorded
@@ -505,9 +537,18 @@ def pull_model(
         if cached_entry is not None:
             cached_path = Path(cached_entry.path)
             resolved_cache = cached_path / subpath if subpath else cached_path
+            if select_gguf:
+                resolved_cache = _select_gguf_path(cached_path)
+                if resolved_cache is None:
+                    raise ModelPullError(
+                        404,
+                        "not_found",
+                        f"No .gguf file found in artifact for llamacpp backend ({source_uri}).",
+                        source_uri,
+                    )
             if resolved_cache.exists() and _verify_cached_digests(cached_entry):
                 return {
-                    "path": str(resolved_cache),
+                    "path": str(resolved_cache.resolve()),
                     "cached": True,
                     "source_uri": source_uri,
                 }
@@ -633,6 +674,10 @@ def pull_model(
         #     (repo://name:version/model.gguf), the returned path points at
         #     that file inside the pulled directory.  A subpath that does
         #     not exist in the artifact is a client error (404).
+        #     When GGUF selection applies (llama.cpp + Harbor artifact, no
+        #     subpath), the path points at the largest *.gguf inside the
+        #     pulled directory; an artifact without any .gguf is a client
+        #     error (404) — the intent can never run on llama.cpp.
         if subpath:
             resolved_path = target_dir / subpath
             if not resolved_path.exists():
@@ -641,6 +686,16 @@ def pull_model(
                     404,
                     "not_found",
                     f"Subpath '{subpath}' not found in artifact for {source_uri}.",
+                    source_uri,
+                )
+        elif select_gguf:
+            resolved_path = _select_gguf_path(target_dir)
+            if resolved_path is None:
+                shutil.rmtree(target_dir, ignore_errors=True)
+                raise ModelPullError(
+                    404,
+                    "not_found",
+                    f"No .gguf file found in artifact for llamacpp backend ({source_uri}).",
                     source_uri,
                 )
         else:

--- a/solar_host/routes/models.py
+++ b/solar_host/routes/models.py
@@ -116,6 +116,11 @@ class PullRequest(BaseModel):
     version: str | None = None
     checksum: str | None = None
     metadata: dict | None = None
+    # Declared by solar-control when the pull targets a specific backend
+    # (e.g. "llamacpp" from an intent).  For harbor artifacts it enables
+    # GGUF selection: the returned path resolves to the largest *.gguf
+    # inside the artifact instead of the directory.  None = no selection.
+    backend_type: str | None = None
 
 
 class PullResponse(BaseModel):
@@ -184,6 +189,7 @@ async def pull_model(req: PullRequest) -> PullResponse | JSONResponse:
             version=req.version,
             checksum=req.checksum,
             metadata=req.metadata,
+            backend_type=req.backend_type,
         )
     except ModelPullError as exc:
         return JSONResponse(

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1113,9 +1113,9 @@ class TestFailureCleanup:
             resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
 
         assert resp.status_code == 200
-        assert removed_before_dl.get("stale_gone") is True, (
-            "Stale directory should have been removed before download started"
-        )
+        assert (
+            removed_before_dl.get("stale_gone") is True
+        ), "Stale directory should have been removed before download started"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -328,6 +328,165 @@ class TestCacheHit:
 
 
 # ---------------------------------------------------------------------------
+# GGUF selection for llama.cpp + repo:// artifacts (fix/repo-resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestGgufSelection:
+    """llama.cpp + harbor pulls resolve to the largest *.gguf in the artifact.
+
+    Selection applies only when the caller declares backend_type ==
+    "llamacpp" on a harbor (repo://) pull without an explicit subpath.
+    local:// and huggingface:// pulls always stay directories.
+    """
+
+    def _mock_pull_files(self, files: dict[str, bytes]):
+        """Side effect for _pull_harbor that writes the given files."""
+
+        def _side_effect(harbor_ref: str, target_dir: Path, source_uri: str):
+            target_dir.mkdir(parents=True, exist_ok=True)
+            for name, data in files.items():
+                file = target_dir / name
+                file.parent.mkdir(parents=True, exist_ok=True)
+                file.write_bytes(data)
+
+        return _side_effect
+
+    def test_fresh_pull_single_gguf_resolves_to_file(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._mock_pull_files({"model.gguf": b"x" * 1024}),
+        ) as mock_pull:
+            body = _harbor_body(backend_type="llamacpp")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is False
+        assert data["path"].endswith("repo--iris-osl--v3/model.gguf")
+        mock_pull.assert_called_once()
+
+    def test_fresh_pull_multiple_ggufs_picks_largest(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._mock_pull_files(
+                {
+                    "small.gguf": b"s" * 512,
+                    "big.gguf": b"b" * 2048,
+                    "README.md": b"readme",
+                }
+            ),
+        ):
+            body = _harbor_body(backend_type="llamacpp")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["path"].endswith("repo--iris-osl--v3/big.gguf")
+
+    def test_fresh_pull_no_gguf_returns_404(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._mock_pull_files({"config.json": b"{}"}),
+        ):
+            body = _harbor_body(backend_type="llamacpp")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 404
+        assert "No .gguf file found" in resp.json()["detail"]
+
+    def test_backend_type_omitted_keeps_directory(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """No backend_type → no selection (existing behavior unchanged)."""
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._mock_pull_files({"model.gguf": b"x" * 1024}),
+        ):
+            resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["path"].endswith("repo--iris-osl--v3")
+
+    def test_hf_source_with_llamacpp_keeps_directory(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        """huggingface:// artifacts are folders even for llamacpp backend."""
+        with patch(
+            "solar_host.models_manager._pull_huggingface",
+            side_effect=self._mock_pull_files(
+                {"model.gguf": b"x" * 1024, "config.json": b"{}"}
+            ),
+        ):
+            body = _hf_body(backend_type="llamacpp")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["path"].endswith("hf--microsoft--phi-3")
+
+    def test_explicit_subpath_wins_over_selection(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        with patch(
+            "solar_host.models_manager._pull_harbor",
+            side_effect=self._mock_pull_files(
+                {
+                    "small.gguf": b"s" * 512,
+                    "big.gguf": b"b" * 2048,
+                    "nested/model.gguf": b"n" * 1024,
+                }
+            ),
+        ):
+            body = _harbor_body(
+                source_uri="repo://iris-osl:v3/small.gguf", backend_type="llamacpp"
+            )
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        assert resp.json()["path"].endswith("repo--iris-osl--v3/small.gguf")
+
+    def test_cache_hit_llamacpp_resolves_to_largest_gguf(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        (slug_dir / "small.gguf").write_bytes(b"s" * 512)
+        (slug_dir / "big.gguf").write_bytes(b"b" * 2048)
+        add_manifest_entry(_make_manifest_entry(path=str(slug_dir.resolve())))
+
+        with patch("solar_host.models_manager._pull_harbor") as mock_pull:
+            body = _harbor_body(backend_type="llamacpp")
+            resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is True
+        assert data["path"] == str((slug_dir / "big.gguf").resolve())
+        mock_pull.assert_not_called()
+
+    def test_cache_hit_llamacpp_no_gguf_returns_404(
+        self, client: TestClient, _isolated_env: Path
+    ):
+        ensure_models_dir()
+        slug_dir = _isolated_env / "repo--iris-osl--v3"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        (slug_dir / "config.json").write_bytes(b"{}")
+        add_manifest_entry(_make_manifest_entry(path=str(slug_dir.resolve())))
+
+        body = _harbor_body(backend_type="llamacpp")
+        resp = client.post("/models/pull", json=body, headers=_headers())
+
+        assert resp.status_code == 404
+        assert "No .gguf file found" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
 # Post-pull digest verification (D-017)
 # ---------------------------------------------------------------------------
 
@@ -954,9 +1113,9 @@ class TestFailureCleanup:
             resp = client.post("/models/pull", json=_harbor_body(), headers=_headers())
 
         assert resp.status_code == 200
-        assert (
-            removed_before_dl.get("stale_gone") is True
-        ), "Stale directory should have been removed before download started"
+        assert removed_before_dl.get("stale_gone") is True, (
+            "Stale directory should have been removed before download started"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
`repo://name:version` resolves to the artifact directory, but llama-server needs a GGUF file — an instance created from a Data Repo GGUF artifact without an explicit subpath failed to start. The pull endpoint now accepts an optional `backend_type`; when it is `llamacpp` and the harbor artifact has no subpath, the returned path resolves to the largest `*.gguf` inside the artifact directory (both cache-hit and fresh-pull paths). Artifacts without any `.gguf` return 404 so the intent fails with a clear message instead of a confusing llama-server error. `local://` and `huggingface://` pulls are never selected; explicit subpaths still win.

## Changes
- `solar_host/models_manager.py`: `_select_gguf_path()` helper (largest root-level `*.gguf`); `pull_model()` gains `backend_type` and applies GGUF selection on cache hit and fresh pull; 404 when a selected artifact has no `.gguf`
- `solar_host/routes/models.py`: `PullRequest` gains optional `backend_type`, forwarded to `pull_model`
- `tests/test_pull.py`: 8 new `TestGgufSelection` cases (single/multi gguf, no gguf → 404, backend_type omitted, HF folder untouched, subpath precedence, cache-hit selection)

## Related Issues
N/A
